### PR TITLE
enable node culling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "graphs",
-  "version": "0.0.1",
+  "name": "@prefecthq/graphs",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "graphs",
-      "version": "0.0.1",
+      "name": "@prefecthq/graphs",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "@pixi-essentials/cull": "^1.1.0",
         "@prefecthq/vue-compositions": "1.0.0",
         "date-fns": "2.29.3",
         "fontfaceobserver": "^2.3.0",
@@ -509,6 +510,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pixi-essentials/cull": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi-essentials/cull/-/cull-1.1.0.tgz",
+      "integrity": "sha512-/IrobYs+ECZoYxGnmCbUBIcye0XX9ZRmeO9SLtOGI0DtsF+/r13OrGX42XUo8L76LMWurv78b5LdYxX33NrUNQ==",
+      "peerDependencies": {
+        "@pixi/display": "^6.0.0",
+        "@pixi/math": "^6.0.0"
       }
     },
     "node_modules/@pixi/accessibility": {
@@ -5155,6 +5165,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@pixi-essentials/cull": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi-essentials/cull/-/cull-1.1.0.tgz",
+      "integrity": "sha512-/IrobYs+ECZoYxGnmCbUBIcye0XX9ZRmeO9SLtOGI0DtsF+/r13OrGX42XUo8L76LMWurv78b5LdYxX33NrUNQ==",
+      "requires": {}
     },
     "@pixi/accessibility": {
       "version": "6.5.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "graphs",
-  "version": "0.0.1",
+  "name": "@prefecthq/graphs",
+  "private": false,
+  "version": "0.1.0",
   "description": "Large scale graphs designed for Prefect",
   "scripts": {
     "serve": "vite --host --mode=demo",
@@ -59,6 +60,7 @@
     "vue-router": "^4.0.12"
   },
   "dependencies": {
+    "@pixi-essentials/cull": "^1.1.0",
     "@prefecthq/vue-compositions": "1.0.0",
     "date-fns": "2.29.3",
     "fontfaceobserver": "^2.3.0",

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,1 @@
 export * from './FlowRunTimeline'
-export * from './GraphNode'
-export * from './State'
-export * from './StateDetails'
-export * from './StateType'

--- a/src/pixiFunctions/timelineGuides.ts
+++ b/src/pixiFunctions/timelineGuides.ts
@@ -94,14 +94,21 @@ export function initTimelineGuides(props: TimelineGuidesProps): void {
     return
   }
 
+  const { stage, app, viewport, isRunning } = props
+
   setTimelineGuidesCurrentTimeGap(props)
   timelineGuidesIdealCount = Math.ceil(
-    props.stage.clientWidth / (timelineGuidesMaxGap - timelineGuidesMinGap / 2))
+    stage.clientWidth / (timelineGuidesMaxGap - timelineGuidesMinGap / 2))
 
-  props.app.ticker.add(() => {
-    // @TODO: Only run update if the viewport has changed to avoid unnecessary work
-    updateTimelineGuides(props)
-  })
+  if (isRunning) {
+    app.ticker.add(() => {
+      updateTimelineGuides(props)
+    })
+  } else {
+    viewport.on('moved', () => {
+      updateTimelineGuides(props)
+    })
+  }
 }
 
 function updateTimelineGuides(props: TimelineGuidesProps): void {


### PR DESCRIPTION
Resolves #14 

Enable broad culling of nodes so they're not drawn when outside the visible area. This will optimize rendering, although there are lots of optimizations that need to take place in the JS when the node list grows to ~100k