### PR TITLE
Enhancement: Optimize the dates const

### DIFF
--- a/src/FlowRunTimeline.vue
+++ b/src/FlowRunTimeline.vue
@@ -109,16 +109,7 @@
   function initTimeScale(): void {
     const minimumTimeSpan = 1000 * 60
 
-    const dates = Array
-      .from(props.graphData)
-      .filter(node => node.end)
-      .flatMap(({
-        start,
-        end,
-      }) => ({
-        start,
-        end,
-      }))
+    const dates = props.graphData.filter(node => node.end).map(({ start, end }) => ({ start, end }))
 
     if (props.isRunning === true) {
       dates.push({


### PR DESCRIPTION
Noticed the `dates` const in the `initTImeScale` method was doing a little more lifting than it needed. 

Removed the `Array.from` since we're immediately calling a filter. `props.graphData` is already an array according to the types and filter returns a new array so there's no need to create another array to start with. 

There was also a flat map that wasn't returning an array which means there was nothing to flatten.

These are micro optimizations but also improves the readability which is the primary goal here.