### PR TITLE
set minimum width of node

### DIFF
--- a/src/pixiFunctions/timelineNode.ts
+++ b/src/pixiFunctions/timelineNode.ts
@@ -64,12 +64,15 @@ export class TimelineNode extends Container {
   }
 
   private drawBox(): void {
+    const width = this.nodeWidth >= 1 ? this.nodeWidth : 1
+    const height = nodeTextStyles.lineHeight + nodeStyles.padding * 2
+
     this.box.beginFill(this.boxColor)
     this.box.drawRoundedRect(
       0,
       0,
-      this.nodeWidth >= 1 ? this.nodeWidth : 1,
-      nodeTextStyles.lineHeight + nodeStyles.padding * 2,
+      width,
+      height,
       nodeStyles.borderRadius,
     )
     this.box.endFill()


### PR DESCRIPTION
When timescales get larger, nodes need a min width so they don't completely disappear, like this:
![image](https://user-images.githubusercontent.com/6776415/212101697-ef11b8f4-8763-4654-bc63-9be54dae7697.png)