### PR TITLE
draw edges from end, minor fixes

### DIFF
--- a/demo/sections/components/FlowRunTimelineDemo.vue
+++ b/demo/sections/components/FlowRunTimelineDemo.vue
@@ -70,7 +70,7 @@
   import { ref, watchEffect, computed, Ref, watch } from 'vue'
   import { generateTimescaleData, Shape, TimescaleItem } from '../../utilities/timescaleData'
   import FlowRunTimeline from '@/FlowRunTimeline.vue'
-  import { TimelineThemeOptions, HSL, TimelineNodesLayoutOptions } from '@/models'
+  import { TimelineThemeOptions, TimelineNodesLayoutOptions, ThemeStyleOverrides } from '@/models'
 
   const { value: colorThemeValue } = useColorTheme()
 
@@ -151,11 +151,7 @@
 
   const computedStyle = getComputedStyle(document.documentElement)
 
-  const colorDefaults = computed<{
-    colorTextDefault: HSL,
-    colorTextInverse: HSL,
-    colorTextSubdued: HSL,
-  }>(() => {
+  const colorDefaults = computed<Partial<ThemeStyleOverrides>>(() => {
     let colorTextDefault = '--foreground',
         colorTextInverse = '--white',
         colorTextSubdued = '--foreground-300',

--- a/src/pixiFunctions/timelineEdge.ts
+++ b/src/pixiFunctions/timelineEdge.ts
@@ -3,7 +3,7 @@ import { ComputedRef, watch, WatchStopHandle } from 'vue'
 import { TimelineNode, timelineNodeBoxName } from './timelineNode'
 import { ParsedThemeStyles } from '@/models'
 
-const minimumBezier = 40
+const minimumBezier = 64
 
 type TimelineEdgeProps = {
   styles: ComputedRef<ParsedThemeStyles>,
@@ -20,7 +20,6 @@ export class TimelineEdge extends Container {
   private sourceY: number = 0
   private targetX: number = 0
   private targetY: number = 0
-  private directionFromSource: 'end' | 'up' | 'down' = 'end'
 
   private readonly edge = new Graphics()
   private readonly arrow = new Graphics()
@@ -52,90 +51,34 @@ export class TimelineEdge extends Container {
   }
 
   private assignStartAndEndPositions(): void {
-    const { spacingMinimumNodeEdgeGap } = this.styles.value
-
     this.sourceX = this.sourceNode.x + this.sourceNode.getChildByName(timelineNodeBoxName).getLocalBounds().width
     this.sourceY = this.sourceNode.y + this.sourceNode.getChildByName(timelineNodeBoxName).getLocalBounds().height / 2
     this.targetX = this.targetNode.x
     this.targetY = this.targetNode.y + this.targetNode.getChildByName(timelineNodeBoxName).getLocalBounds().height / 2
-
-    if (this.sourceX > this.targetX - spacingMinimumNodeEdgeGap) {
-      this.directionFromSource = this.sourceY > this.targetY ? 'up' : 'down'
-
-      if (this.directionFromSource === 'up') {
-        this.sourceY = this.sourceNode.y
-        return
-      }
-
-      this.sourceY = this.sourceNode.y + this.sourceNode.getChildByName(timelineNodeBoxName).getLocalBounds().height
-    }
   }
 
   private drawEdge(): void {
     const { colorEdge, spacingEdgeWidth } = this.styles.value
-    const { edge, targetX, targetY } = this
+    const { edge, sourceX, sourceY, targetX, targetY } = this
 
-    const { sourceX, sourceY } = this.getSourcePosition()
-    const { sourceBezierX, sourceBezierY } = this.getSourceBezier(sourceX)
-    const { targetBezierX, targetBezierY } = this.getTargetBezier()
+    const sourceBezierX = this.getXBezier(sourceX)
+    const targetBezierX = this.getXBezier(targetX, true)
 
     edge.clear()
     edge.lineStyle(spacingEdgeWidth, colorEdge, 1, 0.5)
     edge.moveTo(sourceX, sourceY)
     edge.bezierCurveTo(
-      sourceBezierX, sourceBezierY,
-      targetBezierX, targetBezierY,
+      sourceBezierX, sourceY,
+      targetBezierX, targetY,
       targetX, targetY,
     )
   }
 
-  private readonly getSourcePosition = (): { sourceX: number, sourceY: number } => {
-    const { sourceX, sourceY } = this
-    const { spacingMinimumNodeEdgeGap } = this.styles.value
-
-    if (this.directionFromSource === 'end') {
-      return { sourceX, sourceY }
-    }
-
-    const nodeWidth = this.sourceNode.width
-
-    return {
-      sourceX: nodeWidth > spacingMinimumNodeEdgeGap * 2
-        ? sourceX - spacingMinimumNodeEdgeGap
-        : sourceX - nodeWidth / 2,
-      sourceY,
-    }
-  }
-
-  private readonly getSourceBezier = (srcX: number): { sourceBezierX: number, sourceBezierY: number } => {
-    const { sourceY, targetX, directionFromSource } = this
-
-    if (directionFromSource === 'end') {
-      const bezierLength = (targetX - srcX) / 2
-      const sourceBezierX = srcX + (bezierLength > minimumBezier ? bezierLength : minimumBezier)
-
-      return {
-        sourceBezierX,
-        sourceBezierY: sourceY,
-      }
-    }
-
-    return {
-      sourceBezierX: srcX,
-      sourceBezierY: sourceY,
-    }
-  }
-
-  private readonly getTargetBezier = (): { targetBezierX: number, targetBezierY: number } => {
-    const { targetX, sourceX, targetY } = this
+  private readonly getXBezier = (xPos: number, upstream?: boolean): number => {
+    const { sourceX, targetX } = this
 
     const bezierLength = (targetX - sourceX) / 2
-    const targetBezierX = targetX - (bezierLength > minimumBezier ? bezierLength : minimumBezier)
-
-    return {
-      targetBezierX,
-      targetBezierY: targetY,
-    }
+    return xPos + (bezierLength > minimumBezier ? bezierLength : minimumBezier) * (upstream ? -1 : 1)
   }
 
   private drawArrow(): void {

--- a/src/pixiFunctions/timelineNode.ts
+++ b/src/pixiFunctions/timelineNode.ts
@@ -77,6 +77,7 @@ export class TimelineNode extends Container {
     this.unwatch = watch([styles, styleNode], () => {
       this.box.clear()
       this.drawBox()
+      this.drawLabel()
     }, { deep: true })
 
     this.interactive = true

--- a/src/pixiFunctions/timelineNodes.ts
+++ b/src/pixiFunctions/timelineNodes.ts
@@ -177,7 +177,7 @@ export class TimelineNodes extends Container {
 
     this.nodeRecords.set(nodeData.id, node)
 
-    this.addEdges(nodeData)
+    this.addNodeEdges(nodeData)
 
     this.nodeContainer.addChild(node)
   }
@@ -199,7 +199,7 @@ export class TimelineNodes extends Container {
     )
   }
 
-  private addEdges(nodeData: TimelineNodeData): void {
+  private addNodeEdges(nodeData: TimelineNodeData): void {
     if (!nodeData.upstreamDependencies) {
       return
     }

--- a/src/utilities/style.ts
+++ b/src/utilities/style.ts
@@ -18,7 +18,7 @@ export function parseThemeOptions(overrides?: ThemeStyleOverrides): ParsedThemeS
     spacingViewportPaddingDefault: spacingToNumber(overrides?.spacingViewportPaddingDefault ?? '40px'),
     spacingNodeXPadding: spacingToNumber(overrides?.spacingNodeXPadding ?? '8px'),
     spacingNodeYPadding: spacingToNumber(overrides?.spacingNodeYPadding ?? '8px'),
-    spacingNodeMargin: spacingToNumber(overrides?.spacingNodeMargin ?? '16px'),
+    spacingNodeMargin: spacingToNumber(overrides?.spacingNodeMargin ?? '24px'),
     spacingNodeLabelMargin: spacingToNumber(overrides?.spacingNodeLabelMargin ?? '4px'),
     spacingMinimumNodeEdgeGap: spacingToNumber(overrides?.spacingMinimumNodeEdgeGap ?? '16px'),
     spacingNodeEdgeLength: spacingToNumber(overrides?.spacingNodeEdgeLength ?? '8px'),

--- a/src/workers/tsconfig.json
+++ b/src/workers/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "lib": [
+      "WebWorker",
+      "esnext"
+    ]
+  },
+  "files": [
+    "nodeLayout.worker.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     "./*.ts",
     "./*.d.ts",
     "./postcss.config.js",
-    "./tailwind.config.js"
+    "./tailwind.config.js",
+    "src/workers/tsconfig.json"
   ]
 }


### PR DESCRIPTION
This PR removes some logic that made it so edges would draw from the top or bottom of the node when the target was a close neighbor like so:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/6776415/215484776-b2b33d5d-13e6-4e8a-bbd4-56ea75084e5d.png">

This made it hard to distinguish some edge's origin as it looked like it was passing behind the source node. Now edges simply emit from the end of source nodes like this:
<img width="351" alt="image" src="https://user-images.githubusercontent.com/6776415/215484984-d0c70d3b-e1d0-4739-af0b-e587428d9c34.png">


Also included in this PR:
- Make sure to redraw node labels when the theme updates