### PR TITLE
scale horizontally with node count

### DIFF
--- a/src/FlowRunTimeline.vue
+++ b/src/FlowRunTimeline.vue
@@ -141,7 +141,7 @@
   }
 
   function initTimeScale(): void {
-    const minimumTimeSpan = 1000 * 60
+    const minimumTimeSpan = 1000 * 10
 
     const dates = props.graphData.filter(node => node.end).map(({ start, end }) => ({ start, end }))
 
@@ -157,13 +157,18 @@
     minimumStartDate = min
     maximumEndDate.value = max
     initialOverallTimeSpan = span
-    overallGraphWidth = stage.value!.clientWidth * 2
+    overallGraphWidth = getInitialOverallGraphWidth(stage.value!.clientWidth, props.graphData.length)
 
     timelineScale = initTimelineScale({
       minimumStartTime: minimumStartDate.getTime(),
       overallGraphWidth,
       initialOverallTimeSpan,
     })
+  }
+
+  function getInitialOverallGraphWidth(stageWidth: number, nodeCount: number): number {
+    const multiplier = nodeCount > 30 ? nodeCount / 10 : 2
+    return stageWidth * multiplier
   }
 
   function initFonts(): void {

--- a/src/pixiFunctions/initViewport.ts
+++ b/src/pixiFunctions/initViewport.ts
@@ -27,7 +27,7 @@ export async function initViewport(stage: HTMLElement, appRef: Application): Pro
     .pinch()
     .clampZoom({
       minWidth: width / 2,
-      maxWidth: width * 40,
+      maxWidth: width * 150,
     })
     .decelerate({
       friction: 0.9,


### PR DESCRIPTION
Make the timeScale use horizontal space better with larger flow runs. So rather than having a large flow run compressed to a narrow width and super tall height, use the node count to help determine a nice multiplier for widening the graph.

https://user-images.githubusercontent.com/6776415/222419833-a943be29-df3f-4d3c-8341-da5ad7fa318b.mov

