### PR TITLE
remove guide culling

### DIFF
--- a/src/FlowRunTimeline.vue
+++ b/src/FlowRunTimeline.vue
@@ -285,7 +285,6 @@
     guides = new TimelineGuides({
       viewportRef: viewport,
       appRef: pixiApp,
-      cull,
       minimumStartDate,
       maximumEndDate,
       isRunning: isRunning.value,

--- a/src/pixiFunctions/timelineGuide.ts
+++ b/src/pixiFunctions/timelineGuide.ts
@@ -1,4 +1,3 @@
-import { Cull } from '@pixi-essentials/cull'
 import { Application, BitmapText, Container, Sprite } from 'pixi.js'
 import { ComputedRef } from 'vue'
 import { ParsedThemeStyles } from '@/models'
@@ -9,14 +8,12 @@ type TimelineGuideProps = {
   appRef: Application,
   labelText: string | null,
   styles: ComputedRef<ParsedThemeStyles>,
-  cull: Cull,
 }
 
 export class TimelineGuide extends Container {
   private readonly appRef
   private readonly labelText
   private readonly styles
-  private readonly cull
 
   private guideLine: Sprite | undefined
   private label: BitmapText | undefined
@@ -25,16 +22,12 @@ export class TimelineGuide extends Container {
     appRef,
     labelText,
     styles,
-    cull,
   }: TimelineGuideProps) {
     super()
-
-    cull.add(this)
 
     this.appRef = appRef
     this.labelText = labelText
     this.styles = styles
-    this.cull = cull
 
     this.initGuideLine()
     this.drawLabel()
@@ -74,11 +67,5 @@ export class TimelineGuide extends Container {
 
   public updateHeight(appHeight: number): void {
     this.guideLine!.height = appHeight
-  }
-
-  public destroy(): void {
-    this.cull.remove(this)
-
-    super.destroy()
   }
 }

--- a/src/pixiFunctions/timelineGuides.ts
+++ b/src/pixiFunctions/timelineGuides.ts
@@ -1,4 +1,3 @@
-import { Cull } from '@pixi-essentials/cull'
 import type { Viewport } from 'pixi-viewport'
 import { Application, Container } from 'pixi.js'
 import { ComputedRef, Ref, watch, WatchStopHandle } from 'vue'
@@ -24,7 +23,6 @@ const timelineGuidesRenderPadding = 4000
 type TimelineGuidesProps = {
   viewportRef: Viewport,
   appRef: Application,
-  cull: Cull,
   minimumStartDate: Date,
   maximumEndDate: Ref<Date | undefined>,
   isRunning: boolean,
@@ -35,7 +33,6 @@ type TimelineGuidesProps = {
 export class TimelineGuides extends Container {
   private readonly viewportRef
   private readonly appRef
-  private readonly cull
   private readonly minimumStartDate
   private readonly maximumEndDate
   private readonly isRunning
@@ -52,7 +49,6 @@ export class TimelineGuides extends Container {
   public constructor({
     viewportRef,
     appRef,
-    cull,
     minimumStartDate,
     maximumEndDate,
     isRunning,
@@ -63,7 +59,6 @@ export class TimelineGuides extends Container {
 
     this.viewportRef = viewportRef
     this.appRef = appRef
-    this.cull = cull
     this.minimumStartDate = minimumStartDate
     this.maximumEndDate = maximumEndDate
     this.isRunning = isRunning
@@ -131,7 +126,6 @@ export class TimelineGuides extends Container {
         appRef: this.appRef,
         labelText: this.labelFormatter(lastGuidePoint),
         styles: this.styleOptions,
-        cull: this.cull,
       })
       guide.position.set(this.getGuidePosition(lastGuidePoint), 0)
 


### PR DESCRIPTION
Situations were occurring where visible guides were being culled. We're not getting enough performance gain culling the few guides that are used to justify it. 