### PR TITLE
make graphState more sharable

### DIFF
--- a/src/FlowRunTimeline.vue
+++ b/src/FlowRunTimeline.vue
@@ -115,6 +115,8 @@
   const nodesContentContainerName = 'rootNodesContainer'
   let nodesContainer: TimelineNodes
 
+  let graphState: GraphState | null = null
+
   onMounted(async () => {
     if (!stage.value) {
       console.error('Stage reference not found in initPixiApp')
@@ -131,6 +133,7 @@
     initViewportDragMonitor()
 
     initFonts()
+    initGraphState()
 
     initGuides()
     initContent()
@@ -225,6 +228,26 @@
     })
   }
 
+  function initGraphState(): void {
+    graphState = {
+      pixiApp,
+      viewport,
+      cull,
+      cullScreen,
+      timeScaleProps,
+      styleOptions,
+      styleNode,
+      layoutSetting,
+      isRunning,
+      hideEdges,
+      subNodeLabels,
+      selectedNodeId,
+      expandedSubNodes,
+      suppressMotion,
+      centerViewport,
+    }
+  }
+
   function initPlayhead(): void {
     if (!isRunning.value) {
       return
@@ -285,13 +308,13 @@
   })
 
   function initGuides(): void {
+    if (!graphState) {
+      return
+    }
+
     guides = new TimelineGuides({
-      viewportRef: viewport,
-      appRef: pixiApp,
-      minimumStartDate,
+      graphState,
       maximumEndDate,
-      isRunning: isRunning.value,
-      styleOptions,
       formatDateFns,
     })
 
@@ -330,22 +353,8 @@
   }
 
   function initContent(): void {
-    const graphState: GraphState = {
-      pixiApp,
-      viewport,
-      cull,
-      cullScreen,
-      timeScaleProps,
-      styleOptions,
-      styleNode,
-      layoutSetting,
-      isRunning,
-      hideEdges,
-      subNodeLabels,
-      selectedNodeId,
-      expandedSubNodes,
-      suppressMotion,
-      centerViewport,
+    if (!graphState) {
+      return
     }
 
     nodesContainer = new TimelineNodes({

--- a/src/pixiFunctions/timelineGuide.ts
+++ b/src/pixiFunctions/timelineGuide.ts
@@ -5,29 +5,29 @@ import { getBitmapFonts } from '@/pixiFunctions/bitmapFonts'
 import { getSimpleFillTexture } from '@/pixiFunctions/nodeSprites'
 
 type TimelineGuideProps = {
-  appRef: Application,
+  pixiApp: Application,
   labelText: string | null,
-  styles: ComputedRef<ParsedThemeStyles>,
+  styleOptions: ComputedRef<ParsedThemeStyles>,
 }
 
 export class TimelineGuide extends Container {
-  private readonly appRef
+  private readonly pixiApp
   private readonly labelText
-  private readonly styles
+  private readonly styleOptions
 
   private guideLine: Sprite | undefined
   private label: BitmapText | undefined
 
   public constructor({
-    appRef,
+    pixiApp,
     labelText,
-    styles,
+    styleOptions,
   }: TimelineGuideProps) {
     super()
 
-    this.appRef = appRef
+    this.pixiApp = pixiApp
     this.labelText = labelText
-    this.styles = styles
+    this.styleOptions = styleOptions
 
     this.initGuideLine()
     this.drawLabel()
@@ -36,24 +36,24 @@ export class TimelineGuide extends Container {
   }
 
   private initGuideLine(): void {
-    const { appRef } = this
-    const { colorGuideLine } = this.styles.value
+    const { pixiApp } = this
+    const { colorGuideLine } = this.styleOptions.value
 
     const texture = getSimpleFillTexture({
-      pixiApp: appRef,
+      pixiApp: pixiApp,
       fill: colorGuideLine,
     })
 
     this.guideLine = new Sprite(texture)
     this.guideLine.width = 1
-    this.guideLine.height = appRef.screen.height
+    this.guideLine.height = pixiApp.screen.height
     this.addChild(this.guideLine)
   }
 
   private async drawLabel(): Promise<void> {
     if (this.labelText) {
-      const textStyles = await getBitmapFonts(this.styles.value)
-      const { spacingGuideLabelPadding } = this.styles.value
+      const textStyles = await getBitmapFonts(this.styleOptions.value)
+      const { spacingGuideLabelPadding } = this.styleOptions.value
 
       this.label?.destroy()
       this.label = new BitmapText(this.labelText, textStyles.timeMarkerLabel)


### PR DESCRIPTION
In the Events, I'll want a lot of stuff from `graphState`, just like the nodes are using. Guides already use many of the elements there as well so I updated at least the `timelineGuides` (guides container) to use it. I definitely have more to do around structuring this code better but this core list of stuff is functioning nicely as the individual components can use and subscribe to things and keep themselves up to date.