### PR TITLE
make visible range a v-model

### DIFF
--- a/src/FlowRunTimeline.vue
+++ b/src/FlowRunTimeline.vue
@@ -142,7 +142,8 @@
 
     viewport = await initViewport(stage.value, pixiApp)
     viewport.zIndex = zIndex.viewport
-    initViewportMonitor()
+    initViewportDragMonitor()
+    initDateRangeModel()
 
     initFonts()
     initGraphState()
@@ -168,20 +169,24 @@
     pixiApp.destroy(true)
   }
 
-  function initViewportMonitor(): void {
+  function initViewportDragMonitor(): void {
     viewport
       .on('drag-start', () => {
         isViewportDragging.value = true
       }).on('drag-end', () => {
         isViewportDragging.value = false
       })
-      .on('moved', () => {
-        internalVisibleDateRange.value = {
-          startDate: new Date(timelineScale.xToDate(viewport.left)),
-          endDate: new Date(timelineScale.xToDate(viewport.right)),
-          internalOrigin: true,
-        }
-      })
+  }
+
+  function initDateRangeModel(): void {
+    // Fires continuously as the viewport is moved
+    viewport.on('moved', () => {
+      internalVisibleDateRange.value = {
+        startDate: timelineScale.xToDate(viewport.left),
+        endDate: timelineScale.xToDate(viewport.right),
+        internalOrigin: true,
+      }
+    })
   }
   watch(() => props.visibleDateRange, (newStartDate) => {
     if (newStartDate && !newStartDate.internalOrigin) {
@@ -314,7 +319,7 @@
         ) {
           const originalLeft = timelineScale.xToDate(viewport.left)
           viewport.zoomPercent(-0.1, true)
-          viewport.left = timelineScale.dateToX(new Date(originalLeft))
+          viewport.left = timelineScale.dateToX(originalLeft)
         }
       }
     }

--- a/src/models/FlowRunTimeline.ts
+++ b/src/models/FlowRunTimeline.ts
@@ -94,7 +94,7 @@ export type GraphState = {
 }
 
 export type DateToX = (date: Date) => number
-export type XToDate = (xPosition: number) => number
+export type XToDate = (xPosition: number) => Date
 export type TimelineScale = {
   dateToX: DateToX,
   xToDate: XToDate,

--- a/src/pixiFunctions/timelineGuides.ts
+++ b/src/pixiFunctions/timelineGuides.ts
@@ -92,7 +92,7 @@ export class TimelineGuides extends Container {
     const { minimumStartTime } = this.graphState.timeScaleProps
 
     const pxSpan = Math.ceil((viewport.right - viewport.left) / this.idealGuideCount)
-    const timeSpan = timelineScale.xToDate(pxSpan) - minimumStartTime
+    const timeSpan = timelineScale.xToDate(pxSpan).getTime() - minimumStartTime
 
     const timeSpanSlot = timeSpanSlots.find(timeSlot => timeSlot.ceiling > timeSpan) ?? timeSpanSlots[0]
 
@@ -105,7 +105,7 @@ export class TimelineGuides extends Container {
 
     let lastGuidePoint
     const maxGuidePlacement = timelineScale.xToDate(timelineScale.dateToX(this.maximumEndDate.value ?? new Date()) + timelineGuidesRenderPadding)
-    let firstGuide = new Date(Math.ceil(timelineScale.xToDate(-timelineGuidesRenderPadding) / this.currentTimeGap) * this.currentTimeGap)
+    let firstGuide = new Date(Math.ceil(timelineScale.xToDate(-timelineGuidesRenderPadding).getTime() / this.currentTimeGap) * this.currentTimeGap)
 
     if (this.currentTimeGap > timeLengths.hour * 6) {
       firstGuide = roundDownToNearestDay(firstGuide)
@@ -115,7 +115,7 @@ export class TimelineGuides extends Container {
 
     lastGuidePoint = firstGuide
 
-    while (lastGuidePoint.getTime() < maxGuidePlacement) {
+    while (lastGuidePoint.getTime() < maxGuidePlacement.getTime()) {
       const guide = new TimelineGuide({
         pixiApp,
         labelText: this.labelFormatter(lastGuidePoint),

--- a/src/pixiFunctions/timelineScale.ts
+++ b/src/pixiFunctions/timelineScale.ts
@@ -53,7 +53,7 @@ function createDateToXScale(minStartTime: number, overallWidth: number, overallT
 }
 
 function createXToDateScale(minStartTime: number, overallWidth: number, overallTimeSpan: number): XToDate {
-  return function(xPosition: number): number {
-    return Math.ceil(minStartTime + xPosition * (overallTimeSpan / overallWidth))
+  return function(xPosition: number): Date {
+    return new Date(Math.ceil(minStartTime + xPosition * (overallTimeSpan / overallWidth)))
   }
 }


### PR DESCRIPTION
This allows outside things to subscribe to the current visible date range of the graph.
It also enables the visible start/end date of the graph to be updated externally.

In this video, you can see the new bounds being emitted from the timeline. When I click the "click" button, I'm externally expanding the range by a second on each side (start - 1, end + 1).
https://user-images.githubusercontent.com/6776415/231858372-d4fe6d69-a796-493b-9a61-b69a72997df0.mov