### PR TITLE
Enhancement: Update node date start property to support nulls

### DIFF
--- a/src/models/FlowRunTimeline.ts
+++ b/src/models/FlowRunTimeline.ts
@@ -7,7 +7,7 @@ import { formatDate, formatDateByMinutes, formatDateBySeconds } from '@/utilitie
 export type GraphTimelineNode = {
   id: string,
   label: string,
-  start: Date | null | undefined,
+  start: Date | null,
   end: Date | null,
   state: string,
   upstreamDependencies?: string[],


### PR DESCRIPTION
# Description
Currently the type for node data is a little confusing. 
```typescript
start?: Date,
end: Date | null
```

In actuality this just needs to support null for both start and end like
```typescript
start: Date | null,
end: Date | null,
```

This is technically a breaking change and will break the type for the [mapper in prefect-ui-library.](https://github.com/PrefectHQ/prefect-ui-library/blob/main/src/maps/flowRunTimeline.ts#L9) But that can easily to match the mapping for `end` when updating this package. 