### PR TITLE
Chore: Clean up the initPixiApp function

### DIFF
--- a/src/pixiFunctions/initPixiApp.ts
+++ b/src/pixiFunctions/initPixiApp.ts
@@ -1,13 +1,10 @@
-import { Application, UPDATE_PRIORITY, utils } from 'pixi.js'
+import { Application, utils } from 'pixi.js'
 
 export function initPixiApp(stage: HTMLElement): Application {
-  // Skip the Pixi console message
   utils.skipHello()
 
   const pixiApp = new Application({
     backgroundAlpha: 0,
-    width: stage.clientWidth,
-    height: stage.clientHeight,
     resolution: window.devicePixelRatio || 2,
     autoDensity: true,
     antialias: true,
@@ -19,12 +16,6 @@ export function initPixiApp(stage: HTMLElement): Application {
   }
 
   stage.appendChild(pixiApp.view)
-
-  pixiApp.ticker.add(() => {
-    if (stage.clientWidth !== pixiApp.screen.width || stage.clientHeight !== pixiApp.screen.height) {
-      pixiApp.resizeTo = stage
-    }
-  }, null, UPDATE_PRIORITY.LOW)
 
   return pixiApp
 }


### PR DESCRIPTION
# Description
the `Application.resizeTo` argument automatically syncs the stage with an element. Which means we don't need to set the width and height manually and we don't need to manually resize the stage. 