### PR TITLE
Chore: Use `onUnmounted` hook rather than `onBeforeUnmounted`

### DIFF
--- a/src/FlowRunTimeline.vue
+++ b/src/FlowRunTimeline.vue
@@ -12,7 +12,7 @@
   import {
     computed,
     onMounted,
-    onBeforeUnmount,
+    onUnmounted,
     ref,
     watch
   } from 'vue'
@@ -157,7 +157,7 @@
     loading.value = false
   })
 
-  onBeforeUnmount(() => {
+  onUnmounted(() => {
     cleanupApp()
   })
 


### PR DESCRIPTION
# Description
the before unmounted hook preserves the vue instance until the hook completes.  Using the `onUnmounted` hook means vue can start unmounting the component faster. 

This probably doesn't make much difference. But since we are not using the instance in the callback the `onUnmounted` hook is preferred. 