### PR TITLE
BugFix: Prevent guides crashing if zooming out extremely far

### DIFF
--- a/src/containers/guides.ts
+++ b/src/containers/guides.ts
@@ -21,6 +21,7 @@ type ViewportDates = {
   span: number,
 }
 
+const MAX_GUIDES = 20
 const GUIDE_GAP_PIXELS = 260
 const VIEWPORT_BUFFER = 100
 
@@ -96,6 +97,11 @@ export class Guides extends Container {
     while (date.getTime() < endDate.getTime()) {
       dates.push(date)
       date = addMilliseconds(date, span)
+    }
+
+    while (dates.length > MAX_GUIDES) {
+      dates.shift()
+      dates.pop()
     }
 
     return dates


### PR DESCRIPTION
# Description
Because we have a limited number of "spans" that we use for guides if you zoom out super far you can end up with enough guides being rendered that it crashes the page. Setting a reasonable max number of guides means no matter how many "spans" or what zoom we allow in the future the guides won't crash the page. 