### PR TITLE
Enhancement: Consistently use maps for timeline data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,11 +20,14 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "cSpell.words": [
     "combobox",
+    "gsap",
     "heroicons",
     "pixi",
     "playhead",
     "prefecthq",
+    "subflow",
     "tailwindcss",
+    "unref",
     "vite",
     "vitejs"
   ],

--- a/demo/sections/Data.vue
+++ b/demo/sections/Data.vue
@@ -36,7 +36,7 @@
   import { ref, watchEffect, computed } from 'vue'
   import { generateTimescaleData, Shape } from '../utilities/timescaleData'
   import TimescaleTable from '@/../demo/sections/components/TimescaleTable.vue'
-  import { GraphTimelineNode } from '@/models'
+  import { TimelineData } from '@/types/timeline'
 
   const size = ref(50)
   const fanMultiplier = ref(1.5)
@@ -55,7 +55,7 @@
     }
   })
 
-  const data = ref<GraphTimelineNode[]>([])
+  const data = ref<TimelineData>(new Map())
 
   watchEffect(() => {
     data.value = generateTimescaleData(dataOptions.value)

--- a/demo/sections/components/FlowRunTimelineDemo.vue
+++ b/demo/sections/components/FlowRunTimelineDemo.vue
@@ -118,8 +118,8 @@
   const shapeOptions: Shape[] = ['linear', 'fanOut', 'fanOutIn']
   const slowFeedData = ref(false)
   const zeroTimeGap = ref(true)
-  const layoutOptions: TimelineNodesLayoutOptions[] = ['waterfall', 'nearestParent']
-  const layout = ref<TimelineNodesLayoutOptions>('nearestParent')
+  const layoutOptions: TimelineNodesLayoutOptions[] = ['dag', 'waterfall', 'nearestParent']
+  const layout = ref<TimelineNodesLayoutOptions>('dag')
 
   const dataOptions = computed(() => {
     return {

--- a/demo/sections/components/TimescaleTable.vue
+++ b/demo/sections/components/TimescaleTable.vue
@@ -38,15 +38,18 @@
 </template>
 
 <script lang="ts" setup>
-  import { withDefaults } from 'vue'
-  import { GraphTimelineNode } from '@/models'
+  import { computed, withDefaults } from 'vue'
+
+  import { TimelineData, TimelineItem } from '@/types/timeline'
   import { secondsToApproximateString } from '@/utilities/time'
 
-  withDefaults(defineProps<{
-    data?: GraphTimelineNode[],
+  const props = withDefaults(defineProps<{
+    data?: TimelineData,
   }>(), {
-    data: () => [],
+    data: () => new Map(),
   })
+
+  const data = computed(() => Array.from(props.data.values()))
 
   const columns = [
     {
@@ -71,7 +74,7 @@
     },
   ]
 
-  const getDuration = (row: GraphTimelineNode): string => {
+  const getDuration = (row: TimelineItem): string => {
     if (!row.start) {
       return '--'
     }

--- a/demo/utilities/timescaleData.ts
+++ b/demo/utilities/timescaleData.ts
@@ -145,13 +145,13 @@ const generateTimescaleData = (options?: DataOptions): TimelineData => {
     }
 
     let index = -1
-    for (const [, item] of nodes) {
+    nodes.forEach(item => {
       index++
 
       if (row == 0) {
         rows.push([item])
         incRow()
-        continue
+        return
       }
 
       const currRow = rows[row]
@@ -167,7 +167,7 @@ const generateTimescaleData = (options?: DataOptions): TimelineData => {
         if (currLen + 1 >= prevLen * fanMultiplier) {
           rows[row].push(item)
           incRow()
-          continue
+          return
         }
       }
 
@@ -176,14 +176,14 @@ const generateTimescaleData = (options?: DataOptions): TimelineData => {
           if ((currLen + 1) * fanMultiplier >= prevLen) {
             rows[row].push(item)
             incRow()
-            continue
+            return
           }
         }
 
         if (currLen + 1 >= prevLen * fanMultiplier) {
           rows[row].push(item)
           incRow()
-          continue
+          return
         }
 
       }
@@ -206,7 +206,7 @@ const generateTimescaleData = (options?: DataOptions): TimelineData => {
       if (random() > 0.95) addUpstreamDependency()
       /* eslint-enable curly */
 
-    }
+    })
   }
 
   // Assign start and end dates based on dependency tree

--- a/demo/utilities/timescaleData.ts
+++ b/demo/utilities/timescaleData.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-relative-import-paths/no-relative-import-paths */
 import { randomDate } from './randomDate'
 import { randomStarName } from './randomStarName'
-import { GraphTimelineNode } from '@/models'
+import { TimelineData, TimelineItem } from '@/types/timeline'
 import { random, floor } from '@/utilities/math'
 
 export type TimelineNodeState =
@@ -29,33 +29,40 @@ type AssignStartAndEndDates = {
   start: Date,
   end: Date,
   size: number,
-  nodes: GraphTimelineNode[],
+  nodes: TimelineData,
   zeroTimeGap?: boolean,
 }
 
 // This method assumes that at least 1 upstream dependency has been assigned an end date
-const maxDate = (nodes: GraphTimelineNode[], property: keyof GraphTimelineNode, start: Date): Date => {
-  return nodes.reduce((acc: Date, curr) => {
-    const date = curr[property]
+const maxDate = (data: TimelineData, property: keyof TimelineItem, start: Date): Date => {
+  let max: Date = start
 
-    if (!date) {
-      return acc
-    } else if (!(date instanceof Date)) {
-      throw new Error(`Property ${property} is not a Date`)
-    } else if (date > acc) {
-      return date
-    } else {
-      return acc
+  for (const [, item] of data) {
+    const propertyValue = item[property]
+
+    if (!propertyValue) {
+      continue
     }
-  }, start)
+
+    if (!(propertyValue instanceof Date)) {
+      throw new Error(`Property ${property} is not a Date`)
+    }
+
+    if (propertyValue.getTime() > max.getTime()) {
+      max = propertyValue
+    }
+  }
+
+  return max
 }
 
-const assignStartAndEndDates = ({ start, end, size, nodes, zeroTimeGap }: AssignStartAndEndDates): (node: GraphTimelineNode) => void => {
+const assignStartAndEndDates = ({ start, end, size, nodes, zeroTimeGap }: AssignStartAndEndDates): (node: TimelineItem) => void => {
   const minIncrement = (end.getTime() - start.getTime()) / size
 
-  return (node: GraphTimelineNode) => {
-    const upstreamDependencies = (node.upstreamDependencies ?? [])
-      .map(id => nodes.find(nodeItem => nodeItem.id == id)) as GraphTimelineNode[]
+  return (node: TimelineItem) => {
+    const upstreamDependencies: TimelineData = new Map()
+
+    node.upstream.forEach(id => upstreamDependencies.set(id, nodes.get(id)!))
 
     const minStart = maxDate(upstreamDependencies, 'end', start)
     const maxStart = new Date(minStart.getTime() + minIncrement / 2)
@@ -86,8 +93,8 @@ const randomState = (): TimelineNodeState => {
   return states[floor(random() * states.length)]
 }
 
-const generateTimescaleData = (options?: DataOptions): GraphTimelineNode[] => {
-  const nodes: GraphTimelineNode[] = []
+const generateTimescaleData = (options?: DataOptions): TimelineData => {
+  const nodes: TimelineData = new Map()
   const { size = 5, shape = 'linear', fanMultiplier = 1, start = randomDate(), zeroTimeGap = false } = options ?? {}
   let end = options?.end ?? new Date()
 
@@ -96,12 +103,14 @@ const generateTimescaleData = (options?: DataOptions): GraphTimelineNode[] => {
   }
 
   // Create initial nodes
-  while (nodes.length < size) {
+  while (nodes.size < size) {
     const isSubFlow = options?.subFlowOccurrence ? random() < options.subFlowOccurrence : false
 
-    const target: GraphTimelineNode = {
+    const target: TimelineItem = {
       id: crypto.randomUUID(),
-      upstreamDependencies: [],
+      upstream: [],
+      downstream: [],
+      subflowRunId: null,
       state: randomState(),
       label: randomStarName(),
       start: new Date(),
@@ -109,32 +118,38 @@ const generateTimescaleData = (options?: DataOptions): GraphTimelineNode[] => {
     }
 
     if (isSubFlow) {
-      target.subFlowRunId = crypto.randomUUID()
+      target.subflowRunId = crypto.randomUUID()
     }
 
-    const proxy = new Proxy(target, {})
-    nodes.push(proxy)
+    nodes.set(target.id, target)
   }
 
   // Create dependency tree
   if (shape == 'linear') {
-    for (let i = 1; i < nodes.length; ++i) {
-      nodes[i].upstreamDependencies = [nodes[i - 1].id]
+    const keys = Array.from(nodes.keys())
+
+    for (const [i, key] of keys.entries()) {
+      const item = nodes.get(key)!
+
+      item.upstream = [keys[i - 1]]
     }
   }
 
   if (shape == 'fanOut' || shape == 'fanOutIn') {
     let row = 0
-    const rows = []
+    const rows: TimelineItem[][] = []
 
     const incRow = (): void => {
       row++
       rows[row] = []
     }
 
-    for (let i = 0; i < nodes.length; ++i) {
+    let index = -1
+    for (const [, item] of nodes) {
+      index++
+
       if (row == 0) {
-        rows.push([nodes[i]])
+        rows.push([item])
         incRow()
         continue
       }
@@ -146,41 +161,39 @@ const generateTimescaleData = (options?: DataOptions): GraphTimelineNode[] => {
 
       const upstreamNode = prevRow[floor(random() * prevLen)]
 
-      nodes[i].upstreamDependencies = [upstreamNode.id]
+      item.upstream = [upstreamNode.id]
 
       if (shape == 'fanOut') {
         if (currLen + 1 >= prevLen * fanMultiplier) {
-          rows[row].push(nodes[i])
+          rows[row].push(item)
           incRow()
           continue
         }
       }
 
       if (shape == 'fanOutIn') {
-        if (i > nodes.length / 2) {
+        if (index > nodes.size / 2) {
           if ((currLen + 1) * fanMultiplier >= prevLen) {
-            rows[row].push(nodes[i])
+            rows[row].push(item)
             incRow()
             continue
           }
         }
 
         if (currLen + 1 >= prevLen * fanMultiplier) {
-          rows[row].push(nodes[i])
+          rows[row].push(item)
           incRow()
           continue
         }
 
       }
 
-      rows[row].push(nodes[i])
+      rows[row].push(item)
 
       const addUpstreamDependency = (): void => {
         const upstreamNode = prevRow[floor(random() * prevLen)]
-        if (!nodes[i].upstreamDependencies) {
-          nodes[i].upstreamDependencies = []
-        }
-        nodes[i].upstreamDependencies!.push(upstreamNode.id)
+
+        item.upstream!.push(upstreamNode.id)
       }
 
       /* eslint-disable curly */
@@ -192,6 +205,7 @@ const generateTimescaleData = (options?: DataOptions): GraphTimelineNode[] => {
       if (random() > 0.95) addUpstreamDependency()
       if (random() > 0.95) addUpstreamDependency()
       /* eslint-enable curly */
+
     }
   }
 

--- a/src/FlowRunTimeline.vue
+++ b/src/FlowRunTimeline.vue
@@ -18,7 +18,6 @@
   } from 'vue'
   import { Guides } from '@/containers/guides'
   import {
-    GraphTimelineNode,
     nodeThemeFnDefault,
     TimelineThemeOptions,
     FormatDateFns,
@@ -42,6 +41,7 @@
     createTimeScale,
     nodeClickEvents
   } from '@/pixiFunctions'
+  import { TimelineData } from '@/types/timeline'
   import {
     getDateBounds,
     parseThemeOptions
@@ -51,7 +51,7 @@
   const animationThreshold = 500
 
   const props = defineProps<{
-    graphData: GraphTimelineNode[],
+    data: TimelineData,
     isRunning?: boolean,
     theme?: TimelineThemeOptions,
     formatDateFns?: Partial<FormatDateFns>,
@@ -94,7 +94,7 @@
   const expandedSubNodes = computed(() => props.expandedSubNodes ?? new Map())
   const suppressMotion = computed(() => {
     const prefersReducedMotion: boolean = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    return props.graphData.length > animationThreshold || prefersReducedMotion
+    return props.data.size > animationThreshold || prefersReducedMotion
   })
   const isViewportDragging = ref(false)
   const formatDateFns = computed(() => ({
@@ -217,7 +217,7 @@
 
   function initTimeScaleArgs(): void {
     const minimumTimeSpan = 1000 * 60
-    const { min: minDate, max: maxDate, span } = getDateBounds(props.graphData, minimumTimeSpan, isRunning.value)
+    const { min: minDate, max: maxDate, span } = getDateBounds(props.data, minimumTimeSpan, isRunning.value)
 
     minimumStartDate = minDate
     maximumEndDate.value = maxDate
@@ -240,7 +240,7 @@
       spacingSubNodesOutlineOffset,
     } = styleOptions.value
 
-    const dataSize = props.graphData.length
+    const dataSize = props.data.size
 
     // this nodeHeight measurement is apx because, while it attempts to match the actual node height,
     // we're not measuring an actual node here. e.g. the outlineOffset may not be adding to the
@@ -374,8 +374,8 @@
 
     nodesContainer = new TimelineNodes({
       nodeContentContainerName: nodesContentContainerName,
-      graphData: props.graphData,
-      graphState,
+      data: props.data,
+      state: graphState,
     })
     viewport.addChild(nodesContainer)
 
@@ -390,11 +390,11 @@
       }
     })
 
-    watch(() => props.graphData, () => {
+    watch(() => props.data, () => {
       // This accommodates updated nodeData or newly added nodes.
       // If totally new data is added, it all gets appended way down the viewport Y axis.
       // If nodes are deleted, they are not removed from the viewport (shouldn't happen).
-      nodesContainer.update(props.graphData)
+      nodesContainer.update(props.data)
       viewport.dirty = true
     })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { default as FlowRunTimeline } from './FlowRunTimeline.vue'
+export * from './types'
 export * from './models'

--- a/src/models/FlowRunTimeline.ts
+++ b/src/models/FlowRunTimeline.ts
@@ -26,7 +26,7 @@ export type TimelineVisibleDateRange = {
   internalOrigin?: boolean,
 }
 
-export type TimelineNodesLayoutOptions = 'waterfall' | 'nearestParent'
+export type TimelineNodesLayoutOptions = 'waterfall' | 'nearestParent' | 'dag'
 
 export type NodeSelectionEventTypes = 'task' | 'subFlowRun'
 export type NodeSelectionEvent = {

--- a/src/models/FlowRunTimeline.ts
+++ b/src/models/FlowRunTimeline.ts
@@ -2,17 +2,8 @@ import { Cull } from '@pixi-essentials/cull'
 import type { Viewport } from 'pixi-viewport'
 import type { Application, IBitmapTextStyle, TextStyle } from 'pixi.js'
 import type { ComputedRef } from 'vue'
+import { TimelineData, TimelineItem } from '@/types/timeline'
 import { formatDate, formatDateByMinutes, formatDateBySeconds } from '@/utilities'
-
-export type GraphTimelineNode = {
-  id: string,
-  label: string,
-  start: Date | null,
-  end: Date | null,
-  state: string,
-  upstreamDependencies?: string[],
-  subFlowRunId?: string,
-}
 
 export type TimeScaleArgs = {
   minimumStartTime: number,
@@ -35,20 +26,19 @@ export type NodeSelectionEvent = {
 }
 
 export type ExpandedSubNodes<T extends Record<string, unknown> = Record<string, unknown>> = Map<string, {
-  data: GraphTimelineNode[] | ComputedRef<GraphTimelineNode[]>,
+  data: TimelineData | ComputedRef<TimelineData>,
   // user may define anything else to be used externally
 } & T>
 
 export type NodeShoveDirection = 1 | -1
-export type NodeLayoutWorkerProps = {
-  data: {
-    layoutSetting?: TimelineNodesLayoutOptions,
-    graphData?: string,
-    apxCharacterWidth?: number,
-    spacingMinimumNodeEdgeGap?: number,
-    timeScaleArgs?: TimeScaleArgs,
-    centerViewportAfter?: boolean,
-  },
+
+export type NodeLayoutWorkerArgs = {
+  layoutSetting?: TimelineNodesLayoutOptions,
+  data?: TimelineData,
+  apxCharacterWidth?: number,
+  spacingMinimumNodeEdgeGap?: number,
+  timeScaleArgs?: TimeScaleArgs,
+  centerViewportAfter?: boolean,
 }
 export type NodeLayoutItem = {
   row: number,
@@ -129,7 +119,7 @@ type NodeThemeOptions = {
   onFillSubNodeToggleHoverBg: string,
   onFillSubNodeToggleHoverBgAlpha: number,
 }
-export type NodeThemeFn = (node: GraphTimelineNode) => NodeThemeOptions
+export type NodeThemeFn = (node: TimelineItem) => NodeThemeOptions
 export const nodeThemeFnDefault: NodeThemeFn = () => {
   return {
     fill: 'black',

--- a/src/pixiFunctions/subNodesToggle.ts
+++ b/src/pixiFunctions/subNodesToggle.ts
@@ -1,13 +1,14 @@
 import gsap from 'gsap'
 import { Container, Sprite } from 'pixi.js'
 import { watch, WatchStopHandle } from 'vue'
-import { GraphState, GraphTimelineNode } from '@/models'
+import { GraphState } from '@/models'
 import {
   getArrowTexture,
   getNodeBoxTextures,
   getSimpleFillTexture,
   RoundedBorderRect
 } from '@/pixiFunctions'
+import { TimelineItem } from '@/types/timeline'
 import { colorToHex } from '@/utilities'
 
 const hoverShadePieces = {
@@ -22,7 +23,7 @@ const toggleScaleCullingThreshold = 0.2
 
 type SubNodesToggleProps = {
   graphState: GraphState,
-  nodeData: GraphTimelineNode,
+  nodeData: TimelineItem,
   size: number,
   floating?: boolean,
 }

--- a/src/pixiFunctions/timelineEdge.ts
+++ b/src/pixiFunctions/timelineEdge.ts
@@ -2,7 +2,7 @@ import { Container, Point, SimpleRope, Sprite, Texture } from 'pixi.js'
 import { watch, WatchStopHandle } from 'vue'
 import { GraphState } from '@/models'
 import {
-  TimelineNode,
+  TimelineItem,
   timelineNodeBoxName,
   getArrowTexture,
   getSimpleFillTexture,
@@ -13,9 +13,9 @@ const minimumBezier = 64
 const edgeFidelity = 20
 
 type TimelineEdgeProps = {
-  sourceNode: TimelineNode,
-  targetNode: TimelineNode,
-  graphState: GraphState,
+  sourceNode: TimelineItem,
+  targetNode: TimelineItem,
+  state: GraphState,
 }
 
 export class TimelineEdge extends Container {
@@ -41,13 +41,13 @@ export class TimelineEdge extends Container {
   public constructor({
     sourceNode,
     targetNode,
-    graphState,
+    state,
   }: TimelineEdgeProps) {
     super()
 
     this.sourceNode = sourceNode
     this.targetNode = targetNode
-    this.graphState = graphState
+    this.graphState = state
 
     this.assignBezierPositions()
 
@@ -186,7 +186,7 @@ export class TimelineEdge extends Container {
     return this.sourceNode.x + this.sourceNode.getChildByName(timelineNodeBoxName).getLocalBounds().width
   }
 
-  private getNodeY(node: TimelineNode): number {
+  private getNodeY(node: TimelineItem): number {
     return node.y + node.getChildByName(timelineNodeBoxName).getLocalBounds().height / 2
   }
 

--- a/src/pixiFunctions/timelineEdge.ts
+++ b/src/pixiFunctions/timelineEdge.ts
@@ -2,7 +2,7 @@ import { Container, Point, SimpleRope, Sprite, Texture } from 'pixi.js'
 import { watch, WatchStopHandle } from 'vue'
 import { GraphState } from '@/models'
 import {
-  TimelineItem,
+  TimelineNode,
   timelineNodeBoxName,
   getArrowTexture,
   getSimpleFillTexture,
@@ -13,8 +13,8 @@ const minimumBezier = 64
 const edgeFidelity = 20
 
 type TimelineEdgeProps = {
-  sourceNode: TimelineItem,
-  targetNode: TimelineItem,
+  sourceNode: TimelineNode,
+  targetNode: TimelineNode,
   state: GraphState,
 }
 
@@ -186,7 +186,7 @@ export class TimelineEdge extends Container {
     return this.sourceNode.x + this.sourceNode.getChildByName(timelineNodeBoxName).getLocalBounds().width
   }
 
-  private getNodeY(node: TimelineItem): number {
+  private getNodeY(node: TimelineNode): number {
     return node.y + node.getChildByName(timelineNodeBoxName).getLocalBounds().height / 2
   }
 

--- a/src/pixiFunctions/timelineNode.ts
+++ b/src/pixiFunctions/timelineNode.ts
@@ -163,9 +163,9 @@ export class TimelineNode extends Container {
           this.drawNoSubNodesMessage()
         }
       }, { deep: true }),
-      watch(selectedNodeId, () => {
-        const isCurrentSelection = selectedNodeId.value === this.nodeData.id
-            || selectedNodeId.value === this.nodeData.subflowRunId
+      watch(selectedNodeId, selected => {
+        const nodeSelectionId = this.nodeData.subflowRunId ?? this.nodeData.id
+        const isCurrentSelection = selected && selected === nodeSelectionId
 
         if (isCurrentSelection) {
           this.select()

--- a/src/pixiFunctions/timelineNode.ts
+++ b/src/pixiFunctions/timelineNode.ts
@@ -6,9 +6,8 @@ import {
   TextMetrics,
   UPDATE_PRIORITY
 } from 'pixi.js'
-import { Ref, watch, WatchStopHandle } from 'vue'
+import { Ref, unref, watch, WatchStopHandle } from 'vue'
 import {
-  GraphTimelineNode,
   GraphState,
   NodeLayoutRow,
   NodesLayout,
@@ -25,6 +24,7 @@ import {
   roundedBorderRectAnimationEase,
   LoadingIndicator
 } from '@/pixiFunctions'
+import { TimelineData, TimelineItem } from '@/types/timeline'
 import { colorToHex } from '@/utilities/style'
 
 export const nodeClickEvents = {
@@ -50,8 +50,8 @@ type TimelineNodeUpdatePositionProps = {
 }
 
 type TimelineNodeProps = {
-  nodeData: GraphTimelineNode,
-  graphState: GraphState,
+  nodeData: TimelineItem,
+  state: GraphState,
   layout: Ref<NodesLayout>,
   layoutRows: Ref<NodeLayoutRow[]>,
 }
@@ -102,7 +102,7 @@ export class TimelineNode extends Container {
 
   public constructor({
     nodeData,
-    graphState,
+    state,
     layout,
     layoutRows,
   }: TimelineNodeProps) {
@@ -111,15 +111,15 @@ export class TimelineNode extends Container {
     this.interactive = false
 
     this.nodeData = nodeData
-    this.state = graphState
+    this.state = state
     this.layout = layout
     this.layoutRows = layoutRows
 
     this.currentState = nodeData.state.toString()
-    this.hasSubNodes = nodeData.subFlowRunId !== undefined
+    this.hasSubNodes = nodeData.subflowRunId !== null
     this.updateIsRunningNode()
 
-    this.boxCapWidth = graphState.styleOptions.value.borderRadiusNode
+    this.boxCapWidth = state.styleOptions.value.borderRadiusNode
     this.nodeWidth = this.getNodeWidth()
     this.nodeHeight = this.getNodeHeight()
 
@@ -165,7 +165,7 @@ export class TimelineNode extends Container {
       }, { deep: true }),
       watch(selectedNodeId, () => {
         const isCurrentSelection = selectedNodeId.value === this.nodeData.id
-            || selectedNodeId.value === this.nodeData.subFlowRunId
+            || selectedNodeId.value === this.nodeData.subflowRunId
 
         if (isCurrentSelection) {
           this.select()
@@ -180,17 +180,17 @@ export class TimelineNode extends Container {
     if (hasSubNodes) {
       unWatchers.push(
         watch(expandedSubNodes, () => {
-          if (!this.nodeData.subFlowRunId) {
+          if (!this.nodeData.subflowRunId) {
             return
           }
 
-          if (!this.isSubNodesExpanded && expandedSubNodes.value.has(this.nodeData.subFlowRunId)) {
+          if (!this.isSubNodesExpanded && expandedSubNodes.value.has(this.nodeData.subflowRunId)) {
             this.isSubNodesExpanded = true
             this.subNodesToggle?.setExpanded()
 
             const subNodesData = this.getSubNodesData()
 
-            if (subNodesData.length === 0 && !this.isLoadingSubNodes) {
+            if (subNodesData.size === 0 && !this.isLoadingSubNodes) {
               this.isLoadingSubNodes = true
               this.drawLoadingSubNodes()
               return
@@ -201,7 +201,7 @@ export class TimelineNode extends Container {
           }
 
           if (this.isSubNodesExpanded) {
-            if (!expandedSubNodes.value.has(this.nodeData.subFlowRunId)) {
+            if (!expandedSubNodes.value.has(this.nodeData.subflowRunId)) {
               this.subNodesToggle?.setCollapsed()
 
               this.isSubNodesExpanded = false
@@ -216,7 +216,7 @@ export class TimelineNode extends Container {
             if (this.isLoadingSubNodes) {
               this.isLoadingSubNodes = false
               this.destroySubNodesLoadingIndicator()
-              if (newData.length === 0) {
+              if (newData.size === 0) {
                 this.drawNoSubNodesMessage()
                 return
               }
@@ -491,24 +491,24 @@ export class TimelineNode extends Container {
    * Subnodes
    */
   private expandSubNodes(): void {
-    if (!this.nodeData.subFlowRunId) {
+    if (!this.nodeData.subflowRunId) {
       return
     }
 
-    const subNodeContent = this.state.expandedSubNodes.value.get(this.nodeData.subFlowRunId)
+    const subNodeContent = this.state.expandedSubNodes.value.get(this.nodeData.subflowRunId)
 
     if (!this.hasSubNodes || !subNodeContent) {
       return
     }
 
-    const subNodesData = 'value' in subNodeContent.data ? subNodeContent.data.value : subNodeContent.data
+    const subNodesData = unref(subNodeContent.data)
 
     this.subNodesContent?.destroy()
 
     this.subNodesContent = new TimelineNodes({
       isSubNodes: true,
-      graphData: subNodesData,
-      graphState: this.state,
+      data: subNodesData,
+      state: this.state,
     })
 
     this.subNodesContent.on(nodeClickEvents.nodeDetails, (nodeSelectionValue) => {
@@ -620,7 +620,7 @@ export class TimelineNode extends Container {
   /**
    * Update Functions
    */
-  public update(newData?: GraphTimelineNode): void {
+  public update(newData?: TimelineItem): void {
     let hasNewState = false
     let hasNewLabelText = false
 
@@ -879,10 +879,10 @@ export class TimelineNode extends Container {
     }
 
     const { subNodeLabels } = this.state
-    const { subFlowRunId } = this.nodeData
+    const { subflowRunId } = this.nodeData
 
-    return subNodeLabels.value.has(subFlowRunId!)
-      ? subNodeLabels.value.get(subFlowRunId!)!
+    return subNodeLabels.value.has(subflowRunId!)
+      ? subNodeLabels.value.get(subflowRunId!)!
       : this.nodeData.label
   }
 
@@ -915,23 +915,23 @@ export class TimelineNode extends Container {
   }
 
   private emitSelection(): void {
-    const { id, subFlowRunId } = this.nodeData
+    const { id, subflowRunId } = this.nodeData
 
     const nodeSelectionEvent: NodeSelectionEvent = {
-      id: this.hasSubNodes ? subFlowRunId! : id,
+      id: this.hasSubNodes ? subflowRunId! : id,
       type: this.hasSubNodes ? 'subFlowRun' : 'task',
     }
 
     this.emit(nodeClickEvents.nodeDetails, nodeSelectionEvent)
   }
 
-  private readonly getSubNodesData = (): GraphTimelineNode[] => {
-    if (!this.nodeData.subFlowRunId) {
-      return []
+  private readonly getSubNodesData = (): TimelineData => {
+    if (!this.nodeData.subflowRunId) {
+      return new Map()
     }
 
     const { expandedSubNodes } = this.state
-    const subNodesData = expandedSubNodes.value.get(this.nodeData.subFlowRunId)!.data
+    const subNodesData = expandedSubNodes.value.get(this.nodeData.subflowRunId)!.data
 
     return 'value' in subNodesData ? subNodesData.value : subNodesData
   }
@@ -955,7 +955,7 @@ export class TimelineNode extends Container {
   }
 
   private emitSubNodesToggle(id?: string): void {
-    this.emit(nodeClickEvents.subNodesToggle, id ?? this.nodeData.subFlowRunId)
+    this.emit(nodeClickEvents.subNodesToggle, id ?? this.nodeData.subflowRunId)
   }
 
   private destroySubNodesContent(): void {

--- a/src/pixiFunctions/timelineNodes.ts
+++ b/src/pixiFunctions/timelineNodes.ts
@@ -133,8 +133,6 @@ export class TimelineNodes extends Container {
     this.layoutWorker.onmessage = ({ data }: NodeLayoutWorkerResponse) => {
       this.layout.value = data.layout
 
-      console.log(data.layout)
-
       this.renderLayout()
 
       if (this.isSelectionPathHighlighted) {

--- a/src/pixiFunctions/timelineNodes.ts
+++ b/src/pixiFunctions/timelineNodes.ts
@@ -456,10 +456,14 @@ export class TimelineNodes extends Container {
   }
 
   public getEarliestNodeStart(): Date | null {
-    let earliest: Date | null = null
+    if (this.data.size < 1) {
+      return null
+    }
+
+    let earliest: Date = new Date()
 
     this.data.forEach(({ start }) => {
-      if (start && earliest && start.getTime() < earliest.getTime()) {
+      if (start && start.getTime() < earliest.getTime()) {
         earliest = start
       }
     })

--- a/src/pixiFunctions/timelineNodes.ts
+++ b/src/pixiFunctions/timelineNodes.ts
@@ -1,9 +1,8 @@
 import { Container, TextMetrics } from 'pixi.js'
-import { watch, WatchStopHandle, ref } from 'vue'
+import { watch, WatchStopHandle, ref, toRaw } from 'vue'
 import {
   NodeLayoutWorkerResponse,
-  GraphTimelineNode,
-  NodeLayoutWorkerProps,
+  NodeLayoutWorkerArgs,
   GraphState,
   NodesLayout,
   NodeLayoutRow
@@ -18,6 +17,7 @@ import {
   nodeAnimationDurations,
   getBitmapFonts
 } from '@/pixiFunctions'
+import { TimelineData, TimelineItem } from '@/types/timeline'
 // eslint-disable-next-line import/default
 import LayoutWorker from '@/workers/nodeLayout.worker.ts?worker&inline'
 
@@ -26,8 +26,8 @@ export const timelineUpdateEvent = 'timelineUpdateEvent'
 type TimelineNodesProps = {
   nodeContentContainerName?: string,
   isSubNodes?: boolean,
-  graphData: GraphTimelineNode[],
-  graphState: GraphState,
+  data: TimelineData,
+  state: GraphState,
 }
 
 type EdgeRecord = {
@@ -40,9 +40,8 @@ export class TimelineNodes extends Container {
   private readonly layoutWorker: Worker = new LayoutWorker()
 
   private readonly isSubNodes
-  private graphData
-  private readonly graphDataLookup: Map<string, GraphTimelineNode> = new Map()
-  private readonly graphState: GraphState
+  private data: TimelineData
+  private readonly state: GraphState
 
   private readonly nodeContainer = new Container()
   public readonly nodeRecords: Map<string, TimelineNode> = new Map()
@@ -58,8 +57,8 @@ export class TimelineNodes extends Container {
   public constructor({
     nodeContentContainerName,
     isSubNodes,
-    graphData,
-    graphState,
+    data,
+    state,
   }: TimelineNodesProps) {
     super()
 
@@ -68,9 +67,8 @@ export class TimelineNodes extends Container {
     }
 
     this.isSubNodes = isSubNodes
-    this.graphData = graphData
-    this.setGraphDataLookup()
-    this.graphState = graphState
+    this.data = data
+    this.state = state
 
     this.initDeselectLayer()
     this.initLayoutWorker()
@@ -82,7 +80,7 @@ export class TimelineNodes extends Container {
       layoutSetting,
       hideEdges,
       selectedNodeId,
-    } = this.graphState
+    } = this.state
 
     this.unWatchers.push(
       watch(layoutSetting, () => {
@@ -117,25 +115,25 @@ export class TimelineNodes extends Container {
       layoutSetting,
       centerViewport,
       suppressMotion,
-    } = this.graphState
+    } = this.state
 
     const textStyles = await getBitmapFonts(styleOptions.value)
     const { spacingMinimumNodeEdgeGap } = styleOptions.value
 
     const apxCharacterWidth = TextMetrics.measureText('M', textStyles.nodeTextStyles).width
 
-    const layoutWorkerOptions: NodeLayoutWorkerProps = {
-      data: {
-        graphData: JSON.stringify(this.graphData),
-        timeScaleArgs,
-        spacingMinimumNodeEdgeGap,
-        apxCharacterWidth,
-        layoutSetting: layoutSetting.value,
-      },
+    const layoutWorkerOptions: NodeLayoutWorkerArgs = {
+      data: toRaw(this.data),
+      timeScaleArgs,
+      spacingMinimumNodeEdgeGap,
+      apxCharacterWidth,
+      layoutSetting: layoutSetting.value,
     }
 
     this.layoutWorker.onmessage = ({ data }: NodeLayoutWorkerResponse) => {
       this.layout.value = data.layout
+
+      console.log(data.layout)
 
       this.renderLayout()
 
@@ -153,7 +151,7 @@ export class TimelineNodes extends Container {
       this.emit(timelineUpdateEvent)
     }
 
-    this.layoutWorker.postMessage(layoutWorkerOptions.data)
+    this.layoutWorker.postMessage(layoutWorkerOptions)
   }
 
   private initDeselectLayer(): void {
@@ -161,7 +159,7 @@ export class TimelineNodes extends Container {
       return
     }
 
-    const { pixiApp, viewport } = this.graphState
+    const { pixiApp, viewport } = this.state
 
     const deselectLayer = new DeselectLayer(pixiApp, viewport)
 
@@ -178,7 +176,7 @@ export class TimelineNodes extends Container {
     const newlyCreatedNodes: string[] = []
 
     Object.keys(layout.value).forEach((nodeId) => {
-      const newNodeData = this.getNodeData(nodeId)
+      const newNodeData = this.data.get(nodeId)
 
       if (!newNodeData) {
         return
@@ -203,16 +201,16 @@ export class TimelineNodes extends Container {
       this.addChild(this.nodeContainer)
 
       if (!this.isSubNodes) {
-        this.graphState.centerViewport({ skipAnimation: true })
+        this.state.centerViewport({ skipAnimation: true })
       }
     }
   }
 
-  private createNode(nodeData: GraphTimelineNode): void {
-    const { graphState, layout, layoutRows } = this
+  private createNode(nodeData: TimelineItem): void {
+    const { state: state, layout, layoutRows } = this
     const node = new TimelineNode({
       nodeData,
-      graphState,
+      state,
       layout,
       layoutRows,
     })
@@ -228,12 +226,8 @@ export class TimelineNodes extends Container {
     })
   }
 
-  private addNodeEdges(nodeData: GraphTimelineNode): void {
-    if (!nodeData.upstreamDependencies) {
-      return
-    }
-
-    nodeData.upstreamDependencies.forEach((upstreamDependency) => {
+  private addNodeEdges(nodeData: TimelineItem): void {
+    nodeData.upstream.forEach((upstreamDependency) => {
       const sourceNode = this.nodeRecords.get(upstreamDependency)
       const targetNode = this.nodeRecords.get(nodeData.id)
 
@@ -245,10 +239,10 @@ export class TimelineNodes extends Container {
       const edge = new TimelineEdge({
         sourceNode,
         targetNode,
-        graphState: this.graphState,
+        state: this.state,
       })
 
-      if (this.graphState.hideEdges.value) {
+      if (this.state.hideEdges.value) {
         edge.renderable = false
       }
 
@@ -265,22 +259,21 @@ export class TimelineNodes extends Container {
   /**
    * Update Functions
    */
-  public update(newData: GraphTimelineNode[]): void {
-    this.graphData = newData
-    this.setGraphDataLookup()
+  public update(newData: TimelineData): void {
+    this.data = newData
 
-    if (newData.length !== this.nodeRecords.size) {
-      const message: NodeLayoutWorkerProps = {
-        data: {
-          graphData: JSON.stringify(this.graphData),
-        },
+    if (newData.size !== this.nodeRecords.size) {
+      const message: NodeLayoutWorkerArgs = {
+        data: toRaw(this.data),
       }
-      this.layoutWorker.postMessage(message.data)
+
+      this.layoutWorker.postMessage(message)
       return
     }
 
     this.nodeRecords.forEach((nodeItem, nodeId) => {
-      const newNodeData = this.getNodeData(nodeId)
+      const newNodeData = this.data.get(nodeId)
+
       if (newNodeData) {
         nodeItem.update(newNodeData)
       }
@@ -290,7 +283,7 @@ export class TimelineNodes extends Container {
   }
 
   public updateHideEdges(): void {
-    const { hideEdges, viewport } = this.graphState
+    const { hideEdges, viewport } = this.state
 
     this.edgeRecords.forEach(({ edge }) => edge.renderable = !hideEdges.value)
 
@@ -307,7 +300,7 @@ export class TimelineNodes extends Container {
 
   private updateLayoutRows(position: number = 0): void {
     const { layout } = this
-    const { spacingNodeMargin, spacingNodeSelectionMargin } = this.graphState.styleOptions.value
+    const { spacingNodeMargin, spacingNodeSelectionMargin } = this.state.styleOptions.value
     const maxRows = Math.max(...Object.values(layout.value).map(node => node.row))
     let newLayoutRows: NodeLayoutRow[] = []
 
@@ -344,30 +337,29 @@ export class TimelineNodes extends Container {
   }
 
   public updateLayoutSetting(): void {
-    const { layoutSetting } = this.graphState
+    const { layoutSetting } = this.state
 
-    const message: NodeLayoutWorkerProps = {
-      data: {
-        graphData: JSON.stringify(this.graphData),
-        layoutSetting: layoutSetting.value,
-        centerViewportAfter: true,
-      },
+    const message: NodeLayoutWorkerArgs = {
+      data: toRaw(this.data),
+      layoutSetting: layoutSetting.value,
+      centerViewportAfter: true,
     }
-    this.layoutWorker.postMessage(message.data)
+
+    this.layoutWorker.postMessage(message)
   }
 
   /**
    * Node Selection
    */
   private highlightSelectedNodePath(): void {
-    const selectedNodeId = this.graphState.selectedNodeId.value
+    const selectedNodeId = this.state.selectedNodeId.value
     const selectedNode = selectedNodeId && this.nodeRecords.get(selectedNodeId)
 
     if (!selectedNodeId || !selectedNode) {
       return
     }
 
-    const { alphaNodeDimmed } = this.graphState.styleOptions.value
+    const { alphaNodeDimmed } = this.state.styleOptions.value
 
     const highlightedEdges = [
       ...this.getAllUpstreamEdges(selectedNodeId),
@@ -398,12 +390,13 @@ export class TimelineNodes extends Container {
 
   private getAllUpstreamEdges(nodeId: string): EdgeRecord[] {
     const connectedEdges: EdgeRecord[] = []
+    const nodeData = this.data.get(nodeId)
 
-    const nodeData = this.getNodeData(nodeId)
-    nodeData?.upstreamDependencies?.forEach((upstreamId) => {
+    nodeData?.upstream.forEach((upstreamId) => {
       const edge = this.edgeRecords.find(edgeRecord => {
         return edgeRecord.sourceId === upstreamId && edgeRecord.targetId === nodeId
       })
+
       if (edge) {
         connectedEdges.push(edge)
         const upstreamEdges = this.getAllUpstreamEdges(upstreamId)
@@ -417,8 +410,8 @@ export class TimelineNodes extends Container {
   private getAllDownstreamEdges(nodeId: string): EdgeRecord[] {
     const connectedEdges: EdgeRecord[] = []
 
-    this.graphData.forEach((nodeData) => {
-      if (nodeData.upstreamDependencies?.includes(nodeId)) {
+    this.data.forEach((nodeData) => {
+      if (nodeData.upstream.includes(nodeId)) {
         const edge = this.edgeRecords.find(edgeRecord => {
           return edgeRecord.targetId === nodeData.id && edgeRecord.sourceId === nodeId
         })
@@ -434,7 +427,7 @@ export class TimelineNodes extends Container {
   }
 
   private unHighlightSelectedNodePath(): void {
-    const { hideEdges } = this.graphState
+    const { hideEdges } = this.state
 
     this.edgeRecords.forEach(({ edge }) => {
       if (hideEdges.value) {
@@ -451,12 +444,6 @@ export class TimelineNodes extends Container {
    * Utilities
    */
 
-  private setGraphDataLookup(): void {
-    this.graphData.forEach((node) => {
-      this.graphDataLookup.set(node.id, node)
-    })
-  }
-
   private registerEmits(el: TimelineNode | TimelineNodes): void {
     el.on(nodeClickEvents.nodeDetails, (nodeSelectionValue) => {
       this.emit(nodeClickEvents.nodeDetails, nodeSelectionValue)
@@ -470,24 +457,16 @@ export class TimelineNodes extends Container {
     this.emit(nodeClickEvents.nodeDetails, null)
   }
 
-  private getNodeData(nodeId: string): GraphTimelineNode | undefined {
-    return this.graphDataLookup.get(nodeId)
-  }
-
   public getEarliestNodeStart(): Date | null {
-    if (this.graphData.length < 1) {
-      return null
-    }
+    let earliest: Date | null = null
 
-    const earliestNodeStart = this.graphData.reduce((earliestDate, nodeData) => {
-      if (nodeData.start && nodeData.start.getTime() < earliestDate.getTime()) {
-        return nodeData.start
+    this.data.forEach(({ start }) => {
+      if (start && earliest && start.getTime() < earliest.getTime()) {
+        earliest = start
       }
+    })
 
-      return earliestDate
-    }, new Date())
-
-    return earliestNodeStart
+    return earliest
   }
 
   public destroy(): void {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './timeline'

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -1,0 +1,12 @@
+export type TimelineItem = {
+  id: string,
+  label: string,
+  state: string,
+  start: Date | null,
+  end: Date | null,
+  subflowRunId: string | null,
+  upstream: string[],
+  downstream: string[],
+}
+
+export type TimelineData = Map<string, TimelineItem>

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -105,10 +105,14 @@ export function getDateBounds(
 
     if (startTime && minStartTime) {
       minStartTime = Math.min(minStartTime, startTime)
+    } else {
+      minStartTime = startTime
     }
 
     if (endTime && maxEndTime) {
       maxEndTime = Math.max(maxEndTime, endTime)
+    } else {
+      maxEndTime = endTime
     }
   })
 

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -1,5 +1,6 @@
-import { FormatDateFns, GraphTimelineNode } from '..'
 import { GuideDateFormatter } from '@/containers/guide'
+import { FormatDateFns } from '@/models/FlowRunTimeline'
+import { TimelineData } from '@/types/timeline'
 
 export const intervals = {
   year: 31536000,
@@ -91,28 +92,27 @@ export function formatDate(date: Date): string {
 }
 
 export function getDateBounds(
-  data: GraphTimelineNode[],
+  data: TimelineData,
   minimumTimeSpan: number = 0,
   isRunning: boolean = false,
 ): { min: Date, max: Date, span: number } {
+  let minStartTime: number | null = null
+  let maxEndTime: number | null = isRunning ? new Date().getTime() : null
 
-  const defaultMaxEndTime = isRunning ? new Date().getTime() : null
-
-  const [minStartTime, maxEndTime] = data.reduce<[number | null, number | null]>(([min, max], { start, end }) => {
+  data.forEach(({ start, end }) => {
     const startTime = start?.getTime() ?? null
     const endTime = end?.getTime() ?? null
 
-    if (startTime && min) {
-      min = Math.min(min, startTime)
+    if (startTime && minStartTime) {
+      minStartTime = Math.min(minStartTime, startTime)
     }
 
-    if (endTime && max) {
-      max = Math.max(max, endTime)
+    if (endTime && maxEndTime) {
+      maxEndTime = Math.max(maxEndTime, endTime)
     }
+  })
 
-    return [min ?? startTime, max ?? endTime]
-  }, [null, defaultMaxEndTime])
-
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const min = minStartTime ? new Date(minStartTime) : new Date()
   let max = maxEndTime ? new Date(maxEndTime) : new Date()
   let span = max.getTime() - min.getTime()

--- a/src/workers/layouts/dag.ts
+++ b/src/workers/layouts/dag.ts
@@ -1,0 +1,7 @@
+import { NodesLayout } from '@/models'
+
+export function generateDagLayout(): NodesLayout {
+  const layout: NodesLayout = {}
+
+  return layout
+}

--- a/src/workers/layouts/waterfall.ts
+++ b/src/workers/layouts/waterfall.ts
@@ -1,14 +1,18 @@
-import { GraphTimelineNode, NodesLayout } from '@/models'
+import { NodesLayout } from '@/models'
+import { TimelineData } from '@/types/timeline'
 
-export function generateWaterfallLayout(data: GraphTimelineNode[]): NodesLayout {
+export function generateWaterfallLayout(data: TimelineData): NodesLayout {
   const layout: NodesLayout = {}
+  let index = 0
 
-  data.forEach((nodeData, index) => {
-    layout[nodeData.id] = {
+  data.forEach((item, id) => {
+    layout[id] = {
       row: index,
       startX: 0,
       endX: 0,
     }
+
+    index++
   })
 
   return layout

--- a/src/workers/nodeLayout.worker.ts
+++ b/src/workers/nodeLayout.worker.ts
@@ -1,12 +1,12 @@
 import {
-  GraphTimelineNode,
   TimelineNodesLayoutOptions,
-  NodeLayoutWorkerProps,
+  NodeLayoutWorkerArgs,
   NodesLayout,
   TimeScale,
   NodeLayoutWorkerResponseData
 } from '@/models'
 import { createTimeScale } from '@/pixiFunctions/timeScale'
+import { TimelineData } from '@/types/timeline'
 import { generateNearestParentLayout } from '@/workers/layouts/nearestNeighbor'
 import { generateWaterfallLayout } from '@/workers/layouts/waterfall'
 
@@ -15,20 +15,20 @@ let timeScale: TimeScale | undefined
 let currentApxCharacterWidth = 14
 let minimumNodeEdgeGap = 0
 let currentLayoutSetting: TimelineNodesLayoutOptions = 'waterfall'
-let graphDataStore: GraphTimelineNode[] = []
+let graphDataStore: TimelineData = new Map()
 
 let layout: NodesLayout = {}
 
 onmessage = async ({
   data: {
     layoutSetting,
-    graphData,
+    data,
     apxCharacterWidth,
     spacingMinimumNodeEdgeGap,
     timeScaleArgs,
     centerViewportAfter,
   },
-}: NodeLayoutWorkerProps) => {
+}: { data: NodeLayoutWorkerArgs }) => {
   if (spacingMinimumNodeEdgeGap) {
     minimumNodeEdgeGap = spacingMinimumNodeEdgeGap
   }
@@ -53,41 +53,16 @@ onmessage = async ({
       initialOverallTimeSpan,
     })
   }
-
-  if (graphData) {
-    const newData = JSON.parse(graphData) as GraphTimelineNode[]
-
-    if (timeScale && (layoutSetting || graphDataStore !== newData)) {
-      graphDataStore = prepareGraphData(newData)
-      await calculateNodeLayout()
-      const response: NodeLayoutWorkerResponseData = {
-        layout,
-        centerViewportAfter,
-      }
-      postMessage(response)
+  if (data && timeScale && layoutSetting) {
+    graphDataStore = data
+    await calculateNodeLayout()
+    const response: NodeLayoutWorkerResponseData = {
+      layout,
+      centerViewportAfter,
     }
+    console.log(layout)
+    postMessage(response)
   }
-}
-
-function prepareGraphData(data: GraphTimelineNode[]): GraphTimelineNode[] {
-  return data
-    .filter(isRenderableTimelineNode)
-    .map(node => {
-      // during serialization, dates are converted to strings
-      // so we need to convert them back in this worker
-      node.start = new Date(node.start)
-      if (node.end) {
-        node.end = new Date(node.end)
-      }
-      return node
-    })
-    .sort((nodeA, nodeB) => {
-      return nodeA.start.getTime() - nodeB.start.getTime()
-    })
-}
-
-function isRenderableTimelineNode(value: GraphTimelineNode): value is GraphTimelineNode & { start: Date } {
-  return typeof value === 'object' && 'start' in value
 }
 
 async function calculateNodeLayout(): Promise<void> {

--- a/src/workers/nodeLayout.worker.ts
+++ b/src/workers/nodeLayout.worker.ts
@@ -14,7 +14,7 @@ let timeScale: TimeScale | undefined
 
 let currentApxCharacterWidth = 14
 let minimumNodeEdgeGap = 0
-let currentLayoutSetting: TimelineNodesLayoutOptions = 'waterfall'
+let currentLayoutSetting: TimelineNodesLayoutOptions | undefined
 let graphDataStore: TimelineData = new Map()
 
 let layout: NodesLayout = {}
@@ -53,7 +53,7 @@ onmessage = async ({
       initialOverallTimeSpan,
     })
   }
-  if (data && timeScale && layoutSetting) {
+  if (data && timeScale && currentLayoutSetting) {
     graphDataStore = data
     await calculateNodeLayout()
     const response: NodeLayoutWorkerResponseData = {

--- a/src/workers/nodeLayout.worker.ts
+++ b/src/workers/nodeLayout.worker.ts
@@ -60,7 +60,7 @@ onmessage = async ({
       layout,
       centerViewportAfter,
     }
-    console.log(layout)
+
     postMessage(response)
   }
 }


### PR DESCRIPTION
# Description
Replaces the existing array type with a map type by default. Previously an array was being converted into a map (in multiple places). Requiring a map be passed in prevents having to convert. Also fixes how the data is passed to the worker by using vue's `toRaw` utility so we can preserve the map as is and pass it to the worker. 