### PR TITLE
update guide heights on viewport change

### DIFF
--- a/src/containers/guide.ts
+++ b/src/containers/guide.ts
@@ -72,6 +72,7 @@ export class Guide extends Container {
     }
 
     this.updatePosition()
+    this.updateLineHeight()
   }
 
   private createLine(): void {
@@ -106,6 +107,14 @@ export class Guide extends Container {
     const { viewport } = this.state
 
     return this.state.timeScale.dateToX(this.date) * viewport.scale._x + viewport.worldTransform.tx
+  }
+
+  private updateLineHeight(): void {
+    if (!this.line) {
+      return
+    }
+
+    this.line.height = this.state.pixiApp.screen.height
   }
 
   private updatePosition(): void {

--- a/src/utilities/viewport.ts
+++ b/src/utilities/viewport.ts
@@ -3,17 +3,18 @@ import { Viewport } from 'pixi-viewport'
 export type ViewportUpdatedCheck = () => boolean
 
 export function viewportUpdatedFactory(viewport: Viewport): ViewportUpdatedCheck {
-  let { left: previousLeft, right: previousRight } = viewport
+  let { left: previousLeft, right: previousRight, height: previousHeight } = viewport
 
   function updated(): boolean {
-    const { left, right } = viewport
+    const { left, right, height } = viewport
 
-    if (left === previousLeft && right === previousRight) {
+    if (left === previousLeft && right === previousRight && height === previousHeight) {
       return false
     }
 
     previousLeft = left
     previousRight = right
+    previousHeight = height
 
     return true
   }


### PR DESCRIPTION
When the timeline goes fullscreen, guides weren't matching the full height. This makes guides always have full height.