### PR TITLE
BugFix: Don't throw an error when there are no guides to calculate

### DIFF
--- a/src/containers/guides.ts
+++ b/src/containers/guides.ts
@@ -85,12 +85,12 @@ export class Guides extends Container {
   private getGuideDates(): Date[] {
     const { startDate, endDate } = this.getViewportDates()
     const { span } = this.getTimeSpan()
-    const dates = []
+    const dates: Date[] = []
 
     let date = this.getFirstGuideDate(startDate, span)
 
     if (date.getTime() >= endDate.getTime()) {
-      throw new Error('first guide date is equal or after the desired end date')
+      return dates
     }
 
     while (date.getTime() < endDate.getTime()) {


### PR DESCRIPTION
# Description
Rather than throwing an error when there are no guides to calculate just return. That way it fails gracefully. There might not be any guides to render for a couple reasons
- The nodes haven't been rendered yet.
- The user zooms in far enough that no guides are visible. 