### PR TITLE
Add viewport and organize how pixi objects will get created and shared

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
     "prefecthq",
     "subflow",
     "tailwindcss",
+    "trackpad",
     "unref",
     "vite",
     "vitejs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "date-fns": "2.30.0",
+        "pixi-viewport": "^5.0.2",
         "pixi.js": "^7.3.1"
       },
       "devDependencies": {
@@ -4911,6 +4912,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/pixi-viewport": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-5.0.2.tgz",
+      "integrity": "sha512-U77KnCTl81xEgxEQRFEuI7MYVySWwCVkA41EnM8KiOYwgVOwdBUa7318O+u61IOnTwnoYLzaihy/kpoONKU13Q=="
     },
     "node_modules/pixi.js": {
       "version": "7.3.1",
@@ -9857,6 +9863,11 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="
+    },
+    "pixi-viewport": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-5.0.2.tgz",
+      "integrity": "sha512-U77KnCTl81xEgxEQRFEuI7MYVySWwCVkA41EnM8KiOYwgVOwdBUa7318O+u61IOnTwnoYLzaihy/kpoONKU13Q=="
     },
     "pixi.js": {
       "version": "7.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "date-fns": "2.30.0",
-        "pixi-viewport": "^5.0.2",
-        "pixi.js": "^7.3.1"
+        "pixi-viewport": "5.0.2",
+        "pixi.js": "7.3.1"
       },
       "devDependencies": {
         "@prefecthq/eslint-config": "1.0.31",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "date-fns": "2.30.0",
+    "pixi-viewport": "^5.0.2",
     "pixi.js": "^7.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "date-fns": "2.30.0",
-    "pixi-viewport": "^5.0.2",
-    "pixi.js": "^7.3.1"
+    "pixi-viewport": "5.0.2",
+    "pixi.js": "7.3.1"
   }
 }

--- a/src/components/RunGraph.vue
+++ b/src/components/RunGraph.vue
@@ -3,9 +3,9 @@
 </template>
 
 <script lang="ts" setup>
-  import { onMounted, ref } from 'vue'
+  import { onMounted, onUnmounted, ref } from 'vue'
   import { RunGraphConfig } from '@/models/RunGraph'
-  import { start } from '@/objects'
+  import { start, stop } from '@/objects'
   import { WorkerMessage, worker } from '@/workers/runGraph'
 
   defineProps<{
@@ -34,4 +34,6 @@
 
     start(stage.value)
   })
+
+  onUnmounted(() => stop())
 </script>

--- a/src/components/RunGraph.vue
+++ b/src/components/RunGraph.vue
@@ -1,18 +1,18 @@
 <template>
-  <canvas ref="canvas" />
+  <div ref="stage" />
 </template>
 
 <script lang="ts" setup>
   import { onMounted, ref } from 'vue'
   import { RunGraphConfig } from '@/models/RunGraph'
-  import { createApplication } from '@/objects/application'
+  import { start } from '@/objects'
   import { WorkerMessage, worker } from '@/workers/runGraph'
 
   defineProps<{
     config: RunGraphConfig,
   }>()
 
-  const canvas = ref<HTMLCanvasElement>()
+  const stage = ref<HTMLDivElement>()
 
   worker.onmessage = onMessage
 
@@ -28,16 +28,10 @@
   }
 
   onMounted(() => {
-    if (!canvas.value) {
+    if (!stage.value) {
       throw new Error('Canvas does not exist')
     }
 
-    const view = canvas.value.transferControlToOffscreen()
-
-    createApplication(view)
-
-    if (process.env.NODE_ENV === 'development') {
-      (globalThis as any).__PIXI_STAGE__ = canvas.value
-    }
+    start(stage.value)
   })
 </script>

--- a/src/objects/application.ts
+++ b/src/objects/application.ts
@@ -1,10 +1,19 @@
 import { Application } from 'pixi.js'
+import { stage } from '@/objects/stage'
 
 export let application: Application
 
-export function createApplication(view: OffscreenCanvas): void {
+export function createApplication(): void {
   application = new Application({
-    view,
     background: '#1099bb',
+    resizeTo: stage,
   })
+
+  stage.appendChild(application.view as HTMLCanvasElement)
+
+  if (process.env.NODE_ENV === 'development') {
+    // For whatever reason typing globalThis is not quite working and not worth the time to fix for devtools
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).__PIXI_APP__ = application
+  }
 }

--- a/src/objects/index.ts
+++ b/src/objects/index.ts
@@ -1,0 +1,14 @@
+import { createApplication } from '@/objects/application'
+import { setStage } from '@/objects/stage'
+import { createViewport } from '@/objects/viewport'
+
+export * from './application'
+export * from './stage'
+export * from './viewport'
+
+export function start(stage: HTMLDivElement): void {
+  setStage(stage)
+
+  createApplication()
+  createViewport()
+}

--- a/src/objects/index.ts
+++ b/src/objects/index.ts
@@ -1,4 +1,4 @@
-import { createApplication } from '@/objects/application'
+import { createApplication, application } from '@/objects/application'
 import { setStage } from '@/objects/stage'
 import { createViewport } from '@/objects/viewport'
 
@@ -11,4 +11,10 @@ export function start(stage: HTMLDivElement): void {
 
   createApplication()
   createViewport()
+}
+
+export function stop(): void {
+  application.destroy(true, {
+    children: true,
+  })
 }

--- a/src/objects/stage.ts
+++ b/src/objects/stage.ts
@@ -1,0 +1,5 @@
+export let stage: HTMLDivElement
+
+export function setStage(value: HTMLDivElement): void {
+  stage = value
+}

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -1,0 +1,30 @@
+import { Viewport } from 'pixi-viewport'
+import { Sprite, Texture } from 'pixi.js'
+import { application } from '@/objects/application'
+
+export let viewport: Viewport
+
+export function createViewport(): void {
+  viewport = new Viewport({
+    events: application.renderer.events,
+    passiveWheel: false,
+    worldWidth: 100,
+    worldHeight: 100,
+  })
+
+  viewport
+    .drag()
+    .pinch()
+    .wheel()
+    .decelerate({
+      friction: 0.9,
+    })
+
+  application.stage.addChild(viewport)
+
+  // add a red box
+  const sprite = viewport.addChild(new Sprite(Texture.WHITE))
+  sprite.tint = 0xff0000
+  sprite.width = sprite.height = 100
+  sprite.position.set(100, 100)
+}

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -8,8 +8,6 @@ export function createViewport(): void {
   viewport = new Viewport({
     events: application.renderer.events,
     passiveWheel: false,
-    worldWidth: 100,
-    worldHeight: 100,
   })
 
   viewport


### PR DESCRIPTION
# Description
Gets the viewport wired up

Also trying out a pattern for organizing the various pixi objects. Previously we had a shared state object and returning/passing a lot of stuff around. This takes advantage of exporting `let` variables which cannot be written to when they are imported but can be written to in the same file. 

Also created a `start` method (name will probably change) that will be responsible for running the app and a `stop` method for shutting it down. 