### PR TITLE
Event driven pixi objects and start fetching data

### DIFF
--- a/src/components/RunGraph.vue
+++ b/src/components/RunGraph.vue
@@ -3,21 +3,14 @@
 </template>
 
 <script lang="ts" setup>
-  import { onMounted, onUnmounted, ref, watch } from 'vue'
+  import { onUnmounted, onMounted, ref } from 'vue'
   import { RunGraphConfig } from '@/models/RunGraph'
-  import { setScaleXZoom, start, stop } from '@/objects'
+  import { start, stop } from '@/objects'
   import { WorkerMessage, worker } from '@/workers/runGraph'
 
   const props = defineProps<{
     config: RunGraphConfig,
-    // this will be removed and handled internally to the component itself
-    // this is just a POC for the demo
-    zoom: number,
   }>()
-
-  watch(() => props.zoom, zoom => {
-    setScaleXZoom(zoom)
-  })
 
   const stage = ref<HTMLDivElement>()
 

--- a/src/components/RunGraph.vue
+++ b/src/components/RunGraph.vue
@@ -3,7 +3,8 @@
 </template>
 
 <script lang="ts" setup>
-  import { onUnmounted, onMounted, ref } from 'vue'
+  import { onUnmounted, onMounted, ref, reactive } from 'vue'
+  import { useRunGraphData } from '@/compositions/useRunGraphData'
   import { RunGraphConfig } from '@/models/RunGraph'
   import { start, stop } from '@/objects'
   import { WorkerMessage, worker } from '@/workers/runGraph'
@@ -26,6 +27,9 @@
         throw new Error(`data.type does not have a handler associated with it: ${exhaustive}`)
     }
   }
+
+  const runIds = reactive<string[]>([props.config.runId])
+  const { data } = useRunGraphData(runIds, props.config.fetch)
 
   onMounted(() => {
     if (!stage.value) {

--- a/src/compositions/useRunGraphData.ts
+++ b/src/compositions/useRunGraphData.ts
@@ -1,0 +1,29 @@
+import { UseSubscription, useSubscription } from '@prefecthq/vue-compositions'
+import { ComputedRef, MaybeRefOrGetter, computed, toValue } from 'vue'
+import { RunGraphFetch } from '@/models/RunGraph'
+
+type RunGraphsData = Record<string, UseSubscription<RunGraphFetch>>
+
+function fetchAll(runIds: string[], fetch: RunGraphFetch): RunGraphsData {
+  return runIds.reduce<RunGraphsData>((response, runId) => {
+    response[runId] = useSubscription(fetch, [runId])
+
+    return response
+  }, {})
+}
+
+export type UseRunGraphData = {
+  data: ComputedRef<RunGraphsData>,
+  subscription: UseSubscription<typeof fetchAll>,
+}
+
+export function useRunGraphData(runIds: MaybeRefOrGetter<string[]>, fetch: RunGraphFetch): UseRunGraphData {
+  const parameters = computed<[string[], RunGraphFetch]>(() => [toValue(runIds), fetch])
+  const subscription = useSubscription(fetchAll, parameters)
+  const data = computed(() => subscription.response ?? {})
+
+  return {
+    data,
+    subscription,
+  }
+}

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -28,7 +28,9 @@ export function isRunGraphNodeType(value: unknown): value is RunGraphNodeKind {
   return runGraphNodeKinds.includes(value as RunGraphNodeKind)
 }
 
+export type RunGraphFetch = (flowRunId: string) => RunGraphData | Promise<RunGraphData>
+
 export type RunGraphConfig = {
   runId: string,
-  fetch: (flowRunId: string) => RunGraphData | Promise<RunGraphData>,
+  fetch: RunGraphFetch,
 }

--- a/src/objects/application.ts
+++ b/src/objects/application.ts
@@ -1,15 +1,31 @@
 import { Application } from 'pixi.js'
-import { stage } from '@/objects/stage'
+import { emitter } from '@/objects/events'
 
-export let application: Application
+export let application: Application | null = null
 
-export function createApplication(): void {
+export function startApplication(): void {
+  emitter.on('stageCreated', createApplication)
+}
+
+export function stopApplication(): void {
+  if (!application) {
+    return
+  }
+
+  application.destroy(true, {
+    children: true,
+  })
+}
+
+function createApplication(stage: HTMLDivElement): void {
   application = new Application({
     background: '#1099bb',
     resizeTo: stage,
   })
 
   stage.appendChild(application.view as HTMLCanvasElement)
+
+  emitter.emit('applicationCreated', application)
 
   if (process.env.NODE_ENV === 'development') {
     // For whatever reason typing globalThis is not quite working and not worth the time to fix for devtools

--- a/src/objects/box.ts
+++ b/src/objects/box.ts
@@ -4,7 +4,7 @@ import { Sprite, Texture } from 'pixi.js'
 import { emitter } from '@/objects/events'
 import { scaleX, scaleY } from '@/objects/scales'
 
-let sprite: Sprite
+let sprite: Sprite | null = null
 
 export function startBox(): void {
   emitter.on('viewportCreated', createBox)
@@ -18,6 +18,10 @@ export function createBox(viewport: Viewport): void {
 
 
 export function renderBox(): void {
+  if (!sprite) {
+    return
+  }
+
   const now = new Date()
   const x = scaleX(startOfHour(now))
   const y = scaleY(10)

--- a/src/objects/box.ts
+++ b/src/objects/box.ts
@@ -1,27 +1,30 @@
+import { endOfHour, startOfHour } from 'date-fns'
+import { Viewport } from 'pixi-viewport'
 import { Sprite, Texture } from 'pixi.js'
 import { emitter } from '@/objects/events'
 import { scaleX, scaleY } from '@/objects/scales'
-import { viewport } from '@/objects/viewport'
 
 let sprite: Sprite
 
-// add a red box
-export function createBox(): void {
-  sprite = viewport.addChild(new Sprite(Texture.WHITE))
-  sprite.tint = 0xff0000
-
-  renderBox()
+export function startBox(): void {
+  emitter.on('viewportCreated', createBox)
+  emitter.on('scaleXUpdated', renderBox)
 }
 
+export function createBox(viewport: Viewport): void {
+  sprite = viewport.addChild(new Sprite(Texture.WHITE))
+  sprite.tint = 0xff0000
+}
+
+
 export function renderBox(): void {
-  const x = scaleX(10)
+  const now = new Date()
+  const x = scaleX(startOfHour(now))
   const y = scaleY(10)
-  const width = scaleX(20) - x
+  const width = scaleX(endOfHour(now)) - x
   const height = scaleY(20) - y
 
   sprite.width = Math.max(width, 1)
   sprite.height = height
   sprite.position.set(x, y)
 }
-
-emitter.on('scaleXUpdated', () => renderBox())

--- a/src/objects/events.ts
+++ b/src/objects/events.ts
@@ -1,8 +1,15 @@
 import mitt from 'mitt'
+import { Viewport } from 'pixi-viewport'
+import { Application } from 'pixi.js'
+import { ScaleX, ScaleY } from '@/objects/scales'
 
 type Events = {
-  scaleXUpdated: void,
-  scaleYUpdated: void,
+  scaleXUpdated: ScaleX,
+  scaleYUpdated: ScaleY,
+  applicationCreated: Application,
+  stageCreated: HTMLDivElement,
+  stageResized: HTMLDivElement,
+  viewportCreated: Viewport,
 }
 
 export const emitter = mitt<Events>()

--- a/src/objects/index.ts
+++ b/src/objects/index.ts
@@ -1,8 +1,9 @@
-import { createApplication, application } from '@/objects/application'
-import { createBox } from '@/objects/box'
-import { createScales } from '@/objects/scales'
-import { setStage } from '@/objects/stage'
-import { createViewport } from '@/objects/viewport'
+import { startApplication, stopApplication } from '@/objects/application'
+import { startBox } from '@/objects/box'
+import { emitter } from '@/objects/events'
+import { startScales } from '@/objects/scales'
+import { startStage, stopStage } from '@/objects/stage'
+import { startViewport } from '@/objects/viewport'
 
 export * from './application'
 export * from './stage'
@@ -10,16 +11,17 @@ export * from './viewport'
 export * from './scales'
 
 export function start(stage: HTMLDivElement): void {
-  setStage(stage)
+  startApplication()
+  startViewport()
+  startScales()
+  startBox()
 
-  createApplication()
-  createViewport()
-  createScales()
-  createBox()
+  startStage(stage)
 }
 
 export function stop(): void {
-  application.destroy(true, {
-    children: true,
-  })
+  emitter.all.clear()
+
+  stopApplication()
+  stopStage()
 }

--- a/src/objects/scales.ts
+++ b/src/objects/scales.ts
@@ -1,27 +1,23 @@
-import { ScaleLinear, scaleLinear } from 'd3'
-import { application } from '@/objects/application'
+import { ScaleLinear, scaleLinear, scaleTime, ScaleTime } from 'd3'
 import { emitter } from '@/objects/events'
 
-export let scaleX: ScaleLinear<number, number>
-export let scaleY: ScaleLinear<number, number>
+export let scaleX: ScaleTime<number, number>
+export type ScaleX = typeof scaleX
 
-// these are the same for now but  ScaleXDomain will eventually be [Date, Date]
+export let scaleY: ScaleLinear<number, number>
+export type ScaleY = typeof scaleY
+
 type ScaleRange = [start: number, end: number]
-type ScaleXDomain = [start: number, end: number]
+type ScaleXDomain = [start: Date, end: Date]
 type ScaleYDomain = [start: number, end: number]
 
-export function createScales(): void {
-  createScaleX()
-  createScaleY()
-}
 
-export function createScaleX(): void {
-  const range: ScaleRange = [0, application.view.width]
-  const domain: ScaleXDomain = [0, 100]
+export function startScales(): void {
+  scaleX = scaleTime()
+  scaleY = scaleLinear()
 
-  scaleX = scaleLinear()
-
-  setScaleX({ range, domain, silent: true })
+  emitter.on('stageCreated', updateScaleRanges)
+  emitter.on('stageResized', updateScaleRanges)
 }
 
 type XScale = {
@@ -30,7 +26,7 @@ type XScale = {
   silent?: boolean,
 }
 
-// this needs to be clamped to some minimum range
+// this needs to be clamped to some min/max range
 export function setScaleX({ domain, range, silent }: XScale): void {
   if (range) {
     scaleX.range(range)
@@ -41,17 +37,8 @@ export function setScaleX({ domain, range, silent }: XScale): void {
   }
 
   if (!silent && (range || domain)) {
-    emitter.emit('scaleXUpdated')
+    emitter.emit('scaleXUpdated', scaleX)
   }
-}
-
-export function createScaleY(): void {
-  const range: ScaleRange = [0, application.view.height]
-  const domain: ScaleYDomain = [0, 100]
-
-  scaleY = scaleLinear()
-
-  setScaleY({ range, domain, silent: true })
 }
 
 type YScale = {
@@ -60,7 +47,7 @@ type YScale = {
   silent?: boolean,
 }
 
-// this needs to be clamped to some minimum range
+// this needs to be clamped to some min/max range
 export function setScaleY({ domain, range, silent }: YScale): void {
   if (range) {
     scaleY.range(range)
@@ -71,18 +58,11 @@ export function setScaleY({ domain, range, silent }: YScale): void {
   }
 
   if (!silent && (range || domain)) {
-    emitter.emit('scaleYUpdated')
+    emitter.emit('scaleYUpdated', scaleY)
   }
 }
 
-// proof of concept based on a static number
-// my guess is rather than accepting a static zoom
-// the multiplier would be accepted so a scroll event could pass a positive or negative value
-export function setScaleXZoom(zoom: number): void {
-  const multiplier = 0.2
-  const interval = application.view.width * multiplier
-  const rangeEnd = application.view.width + zoom * interval
-  const range: ScaleRange = [0, rangeEnd]
-
-  setScaleX({ range })
+export function updateScaleRanges(stage: HTMLDivElement): void {
+  setScaleY({ range: [0, stage.clientWidth] })
+  setScaleX({ range: [0, stage.clientHeight] })
 }

--- a/src/objects/stage.ts
+++ b/src/objects/stage.ts
@@ -1,5 +1,23 @@
-export let stage: HTMLDivElement
+import { emitter } from '@/objects/events'
 
-export function setStage(value: HTMLDivElement): void {
+export let stage: HTMLDivElement | null = null
+
+const observer = new ResizeObserver(() => {
+  if (stage) {
+    emitter.emit('stageResized', stage)
+  }
+})
+
+export function startStage(value: HTMLDivElement): void {
   stage = value
+
+  observer.observe(stage)
+
+  emitter.emit('stageCreated', stage)
+}
+
+export function stopStage(): void {
+  if (stage) {
+    observer.unobserve(stage)
+  }
 }

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -1,10 +1,14 @@
 import { Viewport } from 'pixi-viewport'
-import { application } from '@/objects/application'
+import { Application } from 'pixi.js'
+import { emitter } from '@/objects/events'
 
 export let viewport: Viewport
 
-export function createViewport(): void {
+export function startViewport(): void {
+  emitter.on('applicationCreated', createViewport)
+}
 
+export function createViewport(application: Application): void {
   viewport = new Viewport({
     events: application.renderer.events,
     passiveWheel: false,
@@ -19,4 +23,6 @@ export function createViewport(): void {
     })
 
   application.stage.addChild(viewport)
+
+  emitter.emit('viewportCreated', viewport)
 }


### PR DESCRIPTION
# Description
This is an end of day PR with progress towards a few of objectives.

1. Converts objects to be event driven. 
No more importing `application` into other objects. Simply listen for the `applicationCreated` event which contains the application that can be used. This will help with keeping things independent and not getting stuck in a long order dependent list of functions to call. 

2. Update `scaleX` to be `scaleTime` rather than `scaleLinear`. 
3. Start fetching graph data
This graph data will be used to trigger sizing of the scales and rendering tasks and flow runs