### PR TITLE
Date based axis and better startup logic using "waitFor" methods

### DIFF
--- a/demo/sections/components/RunGraphDemo.vue
+++ b/demo/sections/components/RunGraphDemo.vue
@@ -1,23 +1,39 @@
 <template>
   <p-layout-default class="run-graph-demo">
-    <RunGraph :config="config" :zoom="zoom" class="run-graph-demo__graph" />
-    <p-number-input v-model="zoom" />
+    <RunGraph :config="config" class="run-graph-demo__graph" />
+    <!-- <p-number-input v-model="zoom" /> -->
   </p-layout-default>
 </template>
 
 <!-- eslint-disable camelcase -->
 <script lang="ts" setup>
-  import { endOfHour, startOfHour } from 'date-fns'
-  import { ref } from 'vue'
+  import { randomId } from '@prefecthq/prefect-design'
+  import { endOfHour, startOfHour, startOfDay, endOfDay } from 'date-fns'
+  // import { ref } from 'vue'
   import RunGraph from '@/components/RunGraph.vue'
   import { RunGraphConfig, RunGraphData } from '@/models'
 
-  const zoom = ref(0)
+  // const zoom = ref(0)
   const now = new Date()
 
   const dummy: RunGraphData = {
-    start_time: startOfHour(now),
-    end_time: endOfHour(now),
+    start_time: startOfDay(now),
+    end_time: endOfDay(now),
+    root_node_ids: [],
+    nodes: new Map([
+      [
+        randomId(), {
+          start_time: startOfHour(now),
+          end_time: endOfHour(now),
+          kind: 'task-run',
+          state_name: 'Completed',
+          label: 'bar',
+          child_ids: [],
+          parent_ids: [],
+          id: randomId(),
+        },
+      ],
+    ]),
   }
 
   const config: RunGraphConfig = {

--- a/src/components/RunGraph.vue
+++ b/src/components/RunGraph.vue
@@ -5,6 +5,7 @@
 <script lang="ts" setup>
   import { onUnmounted, onMounted, ref, reactive } from 'vue'
   import { useRunGraphData } from '@/compositions/useRunGraphData'
+  import { useRunGraphDomain } from '@/compositions/useRunGraphDomain'
   import { RunGraphConfig } from '@/models/RunGraph'
   import { start, stop } from '@/objects'
   import { WorkerMessage, worker } from '@/workers/runGraph'
@@ -29,7 +30,9 @@
   }
 
   const runIds = reactive<string[]>([props.config.runId])
-  const { data } = useRunGraphData(runIds, props.config.fetch)
+
+  useRunGraphData(runIds, props.config.fetch)
+  useRunGraphDomain(() => props.config.runId, props.config.fetch)
 
   onMounted(() => {
     if (!stage.value) {

--- a/src/components/RunGraph.vue
+++ b/src/components/RunGraph.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { onUnmounted, onMounted, ref, reactive } from 'vue'
+  import { onBeforeUnmount, onMounted, ref, reactive } from 'vue'
   import { useRunGraphData } from '@/compositions/useRunGraphData'
   import { useRunGraphDomain } from '@/compositions/useRunGraphDomain'
   import { RunGraphConfig } from '@/models/RunGraph'
@@ -42,5 +42,7 @@
     start(stage.value)
   })
 
-  onUnmounted(() => stop())
+  onBeforeUnmount(() => {
+    stop()
+  })
 </script>

--- a/src/compositions/useRunGraphDomain.ts
+++ b/src/compositions/useRunGraphDomain.ts
@@ -1,0 +1,38 @@
+import { SubscriptionOptions, UseSubscription, useSubscription } from '@prefecthq/vue-compositions'
+import { ComputedRef, MaybeRefOrGetter, computed, toValue, watch } from 'vue'
+import { RunGraphFetch } from '@/models/RunGraph'
+import { ScaleXDomain, setScaleX } from '@/objects/scales'
+
+export type UseRunGraphDomain = {
+  subscription: UseSubscription<RunGraphFetch>,
+  domain: ComputedRef<ScaleXDomain | null>,
+}
+
+export function useRunGraphDomain(runId: MaybeRefOrGetter<string>, fetch: RunGraphFetch, options?: SubscriptionOptions): UseRunGraphDomain {
+  const parameters = computed<[string]>(() => [toValue(runId)])
+  const subscription = useSubscription(fetch, parameters, options)
+  const domain = computed<ScaleXDomain | null>(() => {
+    const { response } = subscription
+
+    if (!response) {
+      return null
+    }
+    const start = response.start_time
+    const end = response.end_time ?? new Date()
+
+    return [start, end]
+  })
+
+  watch(domain, domain => {
+    if (!domain) {
+      return
+    }
+
+    setScaleX({ domain })
+  }, { immediate: true })
+
+  return {
+    subscription,
+    domain,
+  }
+}

--- a/src/compositions/useRunGraphDomain.ts
+++ b/src/compositions/useRunGraphDomain.ts
@@ -1,7 +1,7 @@
 import { SubscriptionOptions, UseSubscription, useSubscription } from '@prefecthq/vue-compositions'
 import { ComputedRef, MaybeRefOrGetter, computed, toValue, watch } from 'vue'
 import { RunGraphFetch } from '@/models/RunGraph'
-import { ScaleXDomain, setScaleX } from '@/objects/scales'
+import { ScaleXDomain, setScales } from '@/objects/scales'
 
 export type UseRunGraphDomain = {
   subscription: UseSubscription<RunGraphFetch>,
@@ -28,7 +28,7 @@ export function useRunGraphDomain(runId: MaybeRefOrGetter<string>, fetch: RunGra
       return
     }
 
-    setScaleX({ domain })
+    setScales({ x: { domain } })
   }, { immediate: true })
 
   return {

--- a/src/objects/application.ts
+++ b/src/objects/application.ts
@@ -1,10 +1,13 @@
 import { Application } from 'pixi.js'
-import { emitter } from '@/objects/events'
+import { emitter, waitForEvent } from '@/objects/events'
+import { waitForStage } from '@/objects/stage'
 
 export let application: Application | null = null
 
-export function startApplication(): void {
-  emitter.on('stageCreated', createApplication)
+export async function startApplication(): Promise<void> {
+  const stage = await waitForStage()
+
+  createApplication(stage)
 }
 
 export function stopApplication(): void {
@@ -15,6 +18,8 @@ export function stopApplication(): void {
   application.destroy(true, {
     children: true,
   })
+
+  application = null
 }
 
 function createApplication(stage: HTMLDivElement): void {
@@ -32,4 +37,12 @@ function createApplication(stage: HTMLDivElement): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).__PIXI_APP__ = application
   }
+}
+
+export async function waitForApplication(): Promise<Application> {
+  if (application) {
+    return await application
+  }
+
+  return waitForEvent('applicationCreated')
 }

--- a/src/objects/box.ts
+++ b/src/objects/box.ts
@@ -2,13 +2,23 @@ import { endOfHour, startOfHour } from 'date-fns'
 import { Viewport } from 'pixi-viewport'
 import { Sprite, Texture } from 'pixi.js'
 import { emitter } from '@/objects/events'
-import { scaleX, scaleY } from '@/objects/scales'
+import { Scales, waitForScales } from '@/objects/scales'
+import { waitForViewport } from '@/objects/viewport'
 
 let sprite: Sprite | null = null
 
-export function startBox(): void {
-  emitter.on('viewportCreated', createBox)
-  emitter.on('scaleXUpdated', renderBox)
+export async function startBox(): Promise<void> {
+  const viewport = await waitForViewport()
+  createBox(viewport)
+
+  const scales = await waitForScales()
+  renderBox(scales)
+
+  emitter.on('scalesUpdated', renderBox)
+}
+
+export function stopBox(): void {
+  sprite = null
 }
 
 export function createBox(viewport: Viewport): void {
@@ -16,8 +26,7 @@ export function createBox(viewport: Viewport): void {
   sprite.tint = 0xff0000
 }
 
-
-export function renderBox(): void {
+export function renderBox({ scaleX, scaleY }: Scales): void {
   if (!sprite) {
     return
   }

--- a/src/objects/events.ts
+++ b/src/objects/events.ts
@@ -4,11 +4,10 @@ import { Application } from 'pixi.js'
 import { ScaleX, ScaleY } from '@/objects/scales'
 
 type Events = {
-  scaleXUpdated: ScaleX,
-  scaleYUpdated: ScaleY,
+  scaleUpdated: { scaleX: ScaleX, scaleY: ScaleY },
   applicationCreated: Application,
+  stageUpdated: HTMLDivElement,
   stageCreated: HTMLDivElement,
-  stageResized: HTMLDivElement,
   viewportCreated: Viewport,
 }
 

--- a/src/objects/events.ts
+++ b/src/objects/events.ts
@@ -15,6 +15,9 @@ type Events = {
 export const emitter = mitt<Events>()
 
 export function waitForEvent<T extends keyof Events>(event: T): Promise<Events[T]> {
+  // making ts happy with this is just not worth it IMO since this is
+  // only necessary for the emitter.off
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let handler: any
 
   return new Promise<Events[T]>(resolve => {

--- a/src/objects/events.ts
+++ b/src/objects/events.ts
@@ -1,14 +1,28 @@
 import mitt from 'mitt'
 import { Viewport } from 'pixi-viewport'
 import { Application } from 'pixi.js'
-import { ScaleX, ScaleY } from '@/objects/scales'
+import { Scales } from '@/objects/scales'
 
 type Events = {
-  scaleUpdated: { scaleX: ScaleX, scaleY: ScaleY },
+  scalesCreated: Scales,
+  scalesUpdated: Scales,
   applicationCreated: Application,
-  stageUpdated: HTMLDivElement,
   stageCreated: HTMLDivElement,
+  stageUpdated: HTMLDivElement,
   viewportCreated: Viewport,
 }
 
 export const emitter = mitt<Events>()
+
+export function waitForEvent<T extends keyof Events>(event: T): Promise<Events[T]> {
+  let handler: any
+
+  return new Promise<Events[T]>(resolve => {
+    handler = resolve
+    emitter.on(event, handler)
+  }).then(value => {
+    emitter.off(event, handler)
+
+    return value
+  })
+}

--- a/src/objects/index.ts
+++ b/src/objects/index.ts
@@ -1,9 +1,9 @@
 import { startApplication, stopApplication } from '@/objects/application'
-import { startBox } from '@/objects/box'
+import { startBox, stopBox } from '@/objects/box'
 import { emitter } from '@/objects/events'
-import { startScales } from '@/objects/scales'
+import { startScales, stopScales } from '@/objects/scales'
 import { startStage, stopStage } from '@/objects/stage'
-import { startViewport } from '@/objects/viewport'
+import { startViewport, stopViewport } from '@/objects/viewport'
 
 export * from './application'
 export * from './stage'
@@ -23,5 +23,8 @@ export function stop(): void {
   emitter.all.clear()
 
   stopApplication()
+  stopViewport()
+  stopScales()
   stopStage()
+  stopBox()
 }

--- a/src/objects/scales.ts
+++ b/src/objects/scales.ts
@@ -7,27 +7,24 @@ export type ScaleX = typeof scaleX
 export let scaleY: ScaleLinear<number, number>
 export type ScaleY = typeof scaleY
 
-type ScaleRange = [start: number, end: number]
-type ScaleXDomain = [start: Date, end: Date]
-type ScaleYDomain = [start: number, end: number]
-
+export type ScaleRange = [start: number, end: number]
+export type ScaleXDomain = [start: Date, end: Date]
+export type ScaleYDomain = [start: number, end: number]
 
 export function startScales(): void {
   scaleX = scaleTime()
   scaleY = scaleLinear()
 
-  emitter.on('stageCreated', updateScaleRanges)
-  emitter.on('stageResized', updateScaleRanges)
+  emitter.on('stageUpdated', setScaleRanges)
 }
 
 type XScale = {
   domain?: ScaleXDomain,
   range?: ScaleRange,
-  silent?: boolean,
 }
 
 // this needs to be clamped to some min/max range
-export function setScaleX({ domain, range, silent }: XScale): void {
+export function setScaleX({ domain, range }: XScale): void {
   if (range) {
     scaleX.range(range)
   }
@@ -36,19 +33,18 @@ export function setScaleX({ domain, range, silent }: XScale): void {
     scaleX.domain(domain)
   }
 
-  if (!silent && (range || domain)) {
-    emitter.emit('scaleXUpdated', scaleX)
+  if (range || domain) {
+    emitter.emit('scaleUpdated', { scaleX, scaleY })
   }
 }
 
 type YScale = {
   domain?: ScaleYDomain,
   range?: ScaleRange,
-  silent?: boolean,
 }
 
 // this needs to be clamped to some min/max range
-export function setScaleY({ domain, range, silent }: YScale): void {
+export function setScaleY({ domain, range }: YScale): void {
   if (range) {
     scaleY.range(range)
   }
@@ -57,12 +53,12 @@ export function setScaleY({ domain, range, silent }: YScale): void {
     scaleY.domain(domain)
   }
 
-  if (!silent && (range || domain)) {
-    emitter.emit('scaleYUpdated', scaleY)
+  if (range || domain) {
+    emitter.emit('scaleUpdated', { scaleX, scaleY })
   }
 }
 
-export function updateScaleRanges(stage: HTMLDivElement): void {
+function setScaleRanges(stage: HTMLDivElement): void {
   setScaleY({ range: [0, stage.clientWidth] })
   setScaleX({ range: [0, stage.clientHeight] })
 }

--- a/src/objects/scales.ts
+++ b/src/objects/scales.ts
@@ -1,21 +1,34 @@
 import { ScaleLinear, scaleLinear, scaleTime, ScaleTime } from 'd3'
-import { emitter } from '@/objects/events'
+import { emitter, waitForEvent } from '@/objects/events'
 
-export let scaleX: ScaleTime<number, number>
-export type ScaleX = typeof scaleX
+export type Scales = { scaleX: ScaleX, scaleY: ScaleY }
+export type ScaleX = ScaleTime<number, number>
+export let scaleX: ScaleX = scaleTime()
+let scaleXDomainInitialized: boolean = false
+let scaleXRangeInitialized: boolean = false
 
-export let scaleY: ScaleLinear<number, number>
-export type ScaleY = typeof scaleY
+export type ScaleY = ScaleLinear<number, number>
+// scale y domain isn't a concept yet
+export let scaleY: ScaleY = scaleLinear().domain([1, 100])
+// fix this later
+let scaleYDomainInitialized: boolean = true
+let scaleYRangeInitialized: boolean = false
 
 export type ScaleRange = [start: number, end: number]
 export type ScaleXDomain = [start: Date, end: Date]
 export type ScaleYDomain = [start: number, end: number]
 
 export function startScales(): void {
-  scaleX = scaleTime()
-  scaleY = scaleLinear()
-
   emitter.on('stageUpdated', setScaleRanges)
+}
+
+export function stopScales(): void {
+  scaleX = scaleTime()
+  scaleY = scaleLinear().domain([1, 100])
+  scaleXDomainInitialized = false
+  scaleXRangeInitialized = false
+  scaleYDomainInitialized = true
+  scaleYRangeInitialized = false
 }
 
 type XScale = {
@@ -24,17 +37,15 @@ type XScale = {
 }
 
 // this needs to be clamped to some min/max range
-export function setScaleX({ domain, range }: XScale): void {
+function setScaleX({ domain, range }: XScale): void {
   if (range) {
     scaleX.range(range)
+    scaleXRangeInitialized = true
   }
 
   if (domain) {
     scaleX.domain(domain)
-  }
-
-  if (range || domain) {
-    emitter.emit('scaleUpdated', { scaleX, scaleY })
+    scaleXDomainInitialized = true
   }
 }
 
@@ -44,21 +55,58 @@ type YScale = {
 }
 
 // this needs to be clamped to some min/max range
-export function setScaleY({ domain, range }: YScale): void {
+function setScaleY({ domain, range }: YScale): void {
   if (range) {
     scaleY.range(range)
+    scaleYRangeInitialized = true
   }
 
   if (domain) {
     scaleY.domain(domain)
-  }
-
-  if (range || domain) {
-    emitter.emit('scaleUpdated', { scaleX, scaleY })
+    scaleYDomainInitialized = true
   }
 }
 
+export function setScales({ x, y }: { x?: XScale, y?: YScale }): void {
+  const isUpdate = initialized()
+
+  if (x) {
+    setScaleX(x)
+  }
+
+  if (y) {
+    setScaleY(y)
+  }
+
+  if (initialized()) {
+    if (isUpdate) {
+      emitter.emit('scalesUpdated', { scaleX, scaleY })
+      return
+    }
+
+    emitter.emit('scalesCreated', { scaleX, scaleY })
+  }
+}
+
+export function initialized(): boolean {
+  return scaleXDomainInitialized && scaleXRangeInitialized && scaleYDomainInitialized && scaleYRangeInitialized
+}
+
 function setScaleRanges(stage: HTMLDivElement): void {
-  setScaleY({ range: [0, stage.clientWidth] })
-  setScaleX({ range: [0, stage.clientHeight] })
+  setScales({
+    x: {
+      range: [0, stage.clientWidth],
+    },
+    y: {
+      range: [0, stage.clientHeight],
+    },
+  })
+}
+
+export async function waitForScales(): Promise<Scales> {
+  if (initialized()) {
+    return await { scaleX, scaleY }
+  }
+
+  return waitForEvent('scalesCreated')
 }

--- a/src/objects/stage.ts
+++ b/src/objects/stage.ts
@@ -4,7 +4,7 @@ export let stage: HTMLDivElement | null = null
 
 const observer = new ResizeObserver(() => {
   if (stage) {
-    emitter.emit('stageResized', stage)
+    emitter.emit('stageUpdated', stage)
   }
 })
 

--- a/src/objects/stage.ts
+++ b/src/objects/stage.ts
@@ -1,4 +1,4 @@
-import { emitter } from '@/objects/events'
+import { emitter, waitForEvent } from '@/objects/events'
 
 export let stage: HTMLDivElement | null = null
 
@@ -20,4 +20,15 @@ export function stopStage(): void {
   if (stage) {
     observer.unobserve(stage)
   }
+
+  stage = null
+}
+
+
+export async function waitForStage(): Promise<HTMLDivElement> {
+  if (stage) {
+    return await stage
+  }
+
+  return waitForEvent('stageCreated')
 }

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -1,11 +1,18 @@
 import { Viewport } from 'pixi-viewport'
 import { Application } from 'pixi.js'
-import { emitter } from '@/objects/events'
+import { waitForApplication } from '@/objects/application'
+import { emitter, waitForEvent } from '@/objects/events'
 
-export let viewport: Viewport
+export let viewport: Viewport | null = null
 
-export function startViewport(): void {
-  emitter.on('applicationCreated', createViewport)
+export async function startViewport(): Promise<void> {
+  const application = await waitForApplication()
+
+  createViewport(application)
+}
+
+export function stopViewport(): void {
+  viewport = null
 }
 
 export function createViewport(application: Application): void {
@@ -25,4 +32,12 @@ export function createViewport(application: Application): void {
   application.stage.addChild(viewport)
 
   emitter.emit('viewportCreated', viewport)
+}
+
+export async function waitForViewport(): Promise<Viewport> {
+  if (viewport) {
+    return await viewport
+  }
+
+  return waitForEvent('viewportCreated')
 }


### PR DESCRIPTION
# Description
The primary goal of this PR was to introduce the logic for getting and setting the domain for the x axis on the graph. This involves using a subscription to fetch the graph data and a watcher to then set the domain for the axis. That is mostly encapsulated in `useRunGraphDomain.ts`.

While updating the x axis to be date based and respect the domain from the graph data I found some bugs in the initial setup of objects and specifically the scales. This led to a slight refactor, mostly to accomplish 
- Manually stop each object rather than relying on a the vue lifecycle
- Add `waitForEvent` and associated `waitForThing` utilities that make setup dependencies much easier to manage. 