### PR TITLE
Add default config values and add real range for y axis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint": "8.50.0",
         "postcss": "8.4.19",
         "tailwindcss": "3.3.3",
+        "ts-essentials": "^9.4.1",
         "tsc-alias": "1.8.8",
         "typescript": "5.2.2",
         "vite": "4.4.9",
@@ -6568,6 +6569,20 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-essentials": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.4.1.tgz",
+      "integrity": "sha512-oke0rI2EN9pzHsesdmrOrnqv1eQODmJpd/noJjwj2ZPC3Z4N2wbjrOEqnsEgmvlO2+4fBb0a794DCna2elEVIQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -11746,6 +11761,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
       "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "dev": true,
+      "requires": {}
+    },
+    "ts-essentials": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.4.1.tgz",
+      "integrity": "sha512-oke0rI2EN9pzHsesdmrOrnqv1eQODmJpd/noJjwj2ZPC3Z4N2wbjrOEqnsEgmvlO2+4fBb0a794DCna2elEVIQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint": "8.50.0",
     "postcss": "8.4.19",
     "tailwindcss": "3.3.3",
+    "ts-essentials": "^9.4.1",
     "tsc-alias": "1.8.8",
     "typescript": "5.2.2",
     "vite": "4.4.9",

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -1,4 +1,6 @@
 import { ColorSource } from 'pixi.js'
+import { DeepRequired } from 'ts-essentials'
+import { RunGraph } from '..'
 import { StateType } from '@/models/states'
 
 export type RunGraphData = {
@@ -36,15 +38,22 @@ export function isRunGraphNodeType(value: unknown): value is RunGraphNodeKind {
 export type RunGraphFetch = (runId: string) => RunGraphData | Promise<RunGraphData>
 
 export type RunGraphNodeStyles = {
-  background: ColorSource,
+  background?: ColorSource,
 }
 
 export type RunGraphStyles = {
-  node: (node: RunGraphNode) => RunGraphNodeStyles,
+  nodeHeight?: number,
+  node?: (node: RunGraphNode) => RunGraphNodeStyles,
 }
 
 export type RunGraphConfig = {
   runId: string,
   fetch: RunGraphFetch,
-  styles: RunGraphStyles,
+  styles?: RunGraphStyles,
+}
+
+export type RequiredGraphConfig = DeepRequired<RunGraphConfig> & {
+  styles: {
+    node: (node: RunGraphNode) => Required<RunGraphNodeStyles>,
+  },
 }

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -1,6 +1,5 @@
 import { ColorSource } from 'pixi.js'
 import { DeepRequired } from 'ts-essentials'
-import { RunGraph } from '..'
 import { StateType } from '@/models/states'
 
 export type RunGraphData = {

--- a/src/objects/events.ts
+++ b/src/objects/events.ts
@@ -2,7 +2,7 @@ import mitt from 'mitt'
 import { Viewport } from 'pixi-viewport'
 import { Application } from 'pixi.js'
 import { EffectScope } from 'vue'
-import { RunGraphConfig } from '@/models/RunGraph'
+import { RequiredGraphConfig } from '@/models/RunGraph'
 import { RunGraphDomain } from '@/objects/domain'
 import { Fonts } from '@/objects/fonts'
 import { Scales } from '@/objects/scales'
@@ -14,8 +14,8 @@ type Events = {
   stageCreated: HTMLDivElement,
   stageUpdated: HTMLDivElement,
   viewportCreated: Viewport,
-  configCreated: RunGraphConfig,
-  configUpdated: RunGraphConfig,
+  configCreated: RequiredGraphConfig,
+  configUpdated: RequiredGraphConfig,
   scopeCreated: EffectScope,
   domainCreated: RunGraphDomain,
   domainUpdated: RunGraphDomain,

--- a/src/objects/nodes.ts
+++ b/src/objects/nodes.ts
@@ -17,7 +17,7 @@ type NodeSprites = {
 const nodes = new Map<string, NodeSprites>()
 
 // dummy offset for now
-let yOffset = 1
+let yOffset = 0
 
 export async function startNodes(): Promise<void> {
   const config = await waitForConfig()
@@ -29,7 +29,7 @@ export async function startNodes(): Promise<void> {
 
 export function stopNodes(): void {
   nodes.clear()
-  yOffset = 1
+  yOffset = 0
   stopData()
 }
 
@@ -49,11 +49,11 @@ async function renderNode(node: RunGraphNode): Promise<void> {
 
   const offset = yOffset++
   const x = scaleX(node.start_time)
-  const y = scaleY(offset * 5)
+  const y = scaleY(offset)
   const width = scaleX(node.end_time ?? new Date()) - x
-  const height = scaleY(offset * 5 + 4) - y
+  const height = scaleY(offset + 1) - y
 
-  graphics.lineStyle(1, 0x0, 1, 2)
+  // graphics.lineStyle(1, 0x0, 1, 2)
   graphics.beginFill(background)
   graphics.drawRoundedRect(0, 0, width, height, 4)
   graphics.endFill()

--- a/src/objects/scales.ts
+++ b/src/objects/scales.ts
@@ -1,4 +1,5 @@
 import { ScaleLinear, scaleLinear, scaleTime, ScaleTime } from 'd3'
+import { waitForConfig } from '@/objects/config'
 import { RunGraphDomain, waitForDomain } from '@/objects/domain'
 import { emitter, EventKey, waitForEvent } from '@/objects/events'
 import { waitForStage } from '@/objects/stage'
@@ -96,15 +97,25 @@ export function initialized(): boolean {
   return scaleXDomainInitialized && scaleXRangeInitialized && scaleYDomainInitialized && scaleYRangeInitialized
 }
 
-function setScaleRangesFromStage(stage: HTMLDivElement): void {
+async function setScaleRangesFromStage(stage: HTMLDivElement): Promise<void> {
+  const domainY = await getDomainYFromStage(stage)
+
   setScales({
     x: {
       range: [0, stage.clientWidth],
     },
     y: {
+      domain: domainY,
       range: [0, stage.clientHeight],
     },
   })
+}
+
+async function getDomainYFromStage(stage: HTMLDivElement): Promise<ScaleYDomain> {
+  const config = await waitForConfig()
+  const domainYEnd = stage.clientHeight / config.styles.nodeHeight
+
+  return [0, domainYEnd]
 }
 
 function setScaleDomain(domain: RunGraphDomain): void {


### PR DESCRIPTION
# Description
This PR adds the ability for config values to have default values. So any optional config value will get a default value set for it in `config.ts` and when you get a value from the config it will always have a value. 

A new config value was added for `config.styles.nodeHeight`. This value is used not only to size individual nodes but to also to set the domain for the y axis. 

## Node
At some point the domains for the x axis and possibly the y axis will need to be controlled by the component itself as v-models. This is necessary because at implementation the date range being displayed can be modified externally (by zooming/dragging the events visualization in cloud which is synced with this visualization). Probably going to work on that next so some of this y axis implementation is likely to change. But this seemed like a good stopping point to put up a PR. 