### PR TITLE
Add the ability to center the viewport to the world

### DIFF
--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -54,6 +54,7 @@ export type RunGraphStyles = {
 export type RunGraphConfig = {
   runId: string,
   fetch: RunGraphFetch,
+  animationDuration?: number,
   styles?: RunGraphStyles,
 }
 

--- a/src/objects/config.ts
+++ b/src/objects/config.ts
@@ -6,6 +6,7 @@ import { waitForScope } from '@/objects/scope'
 let config: RequiredGraphConfig | null = null
 
 const defaults = {
+  animationDuration: 200,
   styles: {
     nodeHeight: 20,
     node: () => ({
@@ -18,6 +19,7 @@ function withDefaults(config: RunGraphConfig): RequiredGraphConfig {
   return {
     runId: config.runId,
     fetch: config.fetch,
+    animationDuration: config.animationDuration ?? defaults.animationDuration,
     styles: {
       nodeHeight: config.styles?.nodeHeight ?? defaults.styles.nodeHeight,
       node: node => ({

--- a/src/objects/events.ts
+++ b/src/objects/events.ts
@@ -1,6 +1,6 @@
 import mitt from 'mitt'
 import { Viewport } from 'pixi-viewport'
-import { Application } from 'pixi.js'
+import { Application, Container } from 'pixi.js'
 import { EffectScope } from 'vue'
 import { RequiredGraphConfig } from '@/models/RunGraph'
 import { Fonts } from '@/objects/fonts'
@@ -18,6 +18,7 @@ type Events = {
   configUpdated: RequiredGraphConfig,
   scopeCreated: EffectScope,
   fontsLoaded: Fonts,
+  containerCreated: Container,
 }
 
 export type EventKey = keyof Events

--- a/src/objects/nodes.ts
+++ b/src/objects/nodes.ts
@@ -97,6 +97,7 @@ async function renderNode(node: RunGraphNode): Promise<void> {
 }
 
 async function createNode(node: RunGraphNode): Promise<NodeSprites> {
+  const container = await waitForContainer()
   const { inter } = await waitForFonts()
   const graphics = new Graphics()
 
@@ -109,8 +110,8 @@ async function createNode(node: RunGraphNode): Promise<NodeSprites> {
     label,
   })
 
-  container!.addChild(graphics)
-  container!.addChild(label)
+  container.addChild(graphics)
+  container.addChild(label)
 
   return {
     graphics,

--- a/src/objects/nodes.ts
+++ b/src/objects/nodes.ts
@@ -4,7 +4,7 @@ import { waitForConfig } from '@/objects/config'
 import { emitter, waitForEvent } from '@/objects/events'
 import { waitForFonts } from '@/objects/fonts'
 import { waitForScales } from '@/objects/scales'
-import { waitForViewport } from '@/objects/viewport'
+import { centerViewport, waitForViewport } from '@/objects/viewport'
 import { graphDataFactory } from '@/utilities/graphDataFactory'
 
 const { fetch: getData, stop: stopData } = graphDataFactory()
@@ -58,8 +58,16 @@ function stopContainer(): void {
 }
 
 function getGraphData(runId: string): void {
-  getData(runId, data => {
-    data.nodes.forEach(node => renderNode(node))
+  getData(runId, async data => {
+    const promises: Promise<void>[] = []
+
+    data.nodes.forEach(node => {
+      promises.push(renderNode(node))
+    })
+
+    // once we get to "running" runs we'll want to only do this on the first load
+    await Promise.all(promises)
+    centerViewport()
   })
 }
 

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -3,20 +3,30 @@ import { Viewport } from 'pixi-viewport'
 import { watch } from 'vue'
 import { RunGraphProps } from '..'
 import { waitForApplication } from '@/objects/application'
+import { waitForConfig } from '@/objects/config'
 import { emitter, waitForEvent } from '@/objects/events'
+import { waitForContainer } from '@/objects/nodes'
 import { ScaleXDomain, waitForScales } from '@/objects/scales'
 import { waitForScope } from '@/objects/scope'
+import { waitForStage } from '@/objects/stage'
 
 let viewport: Viewport | null = null
 let viewportDateRange: ScaleXDomain | null = null
 
 export async function startViewport(props: RunGraphProps): Promise<void> {
   const application = await waitForApplication()
+  const stage = await waitForStage()
 
   viewport = new Viewport({
+    screenHeight: stage.clientHeight,
+    screenWidth: stage.clientWidth,
     events: application.renderer.events,
     passiveWheel: false,
   })
+
+  console.log(centerViewport)
+
+  console.log(viewport)
 
   viewport
     .drag()
@@ -37,6 +47,31 @@ export async function startViewport(props: RunGraphProps): Promise<void> {
 export function stopViewport(): void {
   viewport = null
   viewportDateRange = null
+}
+
+type CenterViewportParameters = {
+  animate?: boolean,
+}
+
+export async function centerViewport({ animate }: CenterViewportParameters = {}): Promise<void> {
+  const viewport = await waitForViewport()
+  const container = await waitForContainer()
+  const config = await waitForConfig()
+
+  // when we get to culling we might need to turn it off for this measurement
+  const { x, y, width, height } = container.getLocalBounds()
+  const scale = viewport.findFit(width, height)
+
+  viewport.animate({
+    position: {
+      x: x + width / 2,
+      y: y + height / 2,
+    },
+    scale,
+    time: animate ? config.animationDuration : 0,
+    callbackOnComplete: () => updateViewportDateRange(),
+  })
+
 }
 
 export async function waitForViewport(): Promise<Viewport> {
@@ -71,12 +106,15 @@ async function watchVisibleDateRange(props: RunGraphProps): Promise<void> {
 
 async function startViewportDateRange(): Promise<void> {
   const viewport = await waitForViewport()
+
+  viewport.on('moved', () => updateViewportDateRange())
+}
+
+async function updateViewportDateRange(): Promise<void> {
+  const viewport = await waitForViewport()
   const { scaleX } = await waitForScales()
+  const left = scaleX.invert(viewport.left)
+  const right = scaleX.invert(viewport.right)
 
-  viewport.on('moved', event => {
-    const left = scaleX.invert(event.viewport.left)
-    const right = scaleX.invert(event.viewport.right)
-
-    setViewportDateRange([left, right])
-  })
+  setViewportDateRange([left, right])
 }

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -1,7 +1,7 @@
 import isEqual from 'lodash.isequal'
 import { Viewport } from 'pixi-viewport'
 import { watch } from 'vue'
-import { RunGraphProps } from '..'
+import { RunGraphProps } from '@/models/RunGraph'
 import { waitForApplication } from '@/objects/application'
 import { waitForConfig } from '@/objects/config'
 import { emitter, waitForEvent } from '@/objects/events'
@@ -23,10 +23,6 @@ export async function startViewport(props: RunGraphProps): Promise<void> {
     events: application.renderer.events,
     passiveWheel: false,
   })
-
-  console.log(centerViewport)
-
-  console.log(viewport)
 
   viewport
     .drag()
@@ -106,6 +102,8 @@ async function watchVisibleDateRange(props: RunGraphProps): Promise<void> {
 
 async function startViewportDateRange(): Promise<void> {
   const viewport = await waitForViewport()
+
+  updateViewportDateRange()
 
   viewport.on('moved', () => updateViewportDateRange())
 }

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -54,9 +54,15 @@ export async function centerViewport({ animate }: CenterViewportParameters = {})
   const container = await waitForContainer()
   const config = await waitForConfig()
 
+
   // when we get to culling we might need to turn it off for this measurement
   const { x, y, width, height } = container.getLocalBounds()
   const scale = viewport.findFit(width, height)
+
+  // if the container doesn't have a size we cannot do anything here
+  if (!width || !height) {
+    return
+  }
 
   viewport.animate({
     position: {


### PR DESCRIPTION
# Description
Adds a `centerViewport` method that will automatically scale and center the graph in the viewport

Also fixes an issue where the viewportDateRange was not set when the viewport was started. 