### PR TITLE
Draw nodes prior to doing layout

### DIFF
--- a/src/components/RunGraph.vue
+++ b/src/components/RunGraph.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="stage" />
+  <div ref="stage" class="run-graph" />
 </template>
 
 <script lang="ts" setup>
@@ -49,3 +49,10 @@
     stop()
   })
 </script>
+
+<style>
+.run-graph > canvas {
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -56,10 +56,12 @@ export type RunGraphConfig = {
   runId: string,
   fetch: RunGraphFetch,
   animationDuration?: number,
+  nodeRenderKey?: (node: RunGraphNode) => string,
   styles?: RunGraphStyles,
 }
 
 export type RequiredGraphConfig = DeepRequired<RunGraphConfig> & {
+  nodeRenderKey: (node: RunGraphNode) => string,
   styles: {
     node: (node: RunGraphNode) => Required<RunGraphNodeStyles>,
   },

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -48,6 +48,7 @@ export type RunGraphNodeStyles = {
 
 export type RunGraphStyles = {
   nodeHeight?: number,
+  nodeMargin?: number,
   node?: (node: RunGraphNode) => RunGraphNodeStyles,
 }
 

--- a/src/objects/application.ts
+++ b/src/objects/application.ts
@@ -27,6 +27,7 @@ function createApplication(stage: HTMLDivElement): void {
     backgroundAlpha: 0,
     resizeTo: stage,
     antialias: true,
+    resolution: window.devicePixelRatio,
   })
 
   stage.appendChild(application.view as HTMLCanvasElement)

--- a/src/objects/config.ts
+++ b/src/objects/config.ts
@@ -7,7 +7,7 @@ let config: RequiredGraphConfig | null = null
 
 const defaults = {
   animationDuration: 200,
-  nodeRenderKey: (node) => `${node.kind},${node.start_time},${node.end_time},${node.state_type},${node.label}`,
+  nodeRenderKey: (node) => `${node.id},${node.kind},${node.start_time},${node.end_time},${node.state_type},${node.label}`,
   styles: {
     nodeHeight: 30,
     nodeMargin: 2,

--- a/src/objects/config.ts
+++ b/src/objects/config.ts
@@ -9,6 +9,7 @@ const defaults = {
   animationDuration: 200,
   styles: {
     nodeHeight: 20,
+    nodeMargin: 2,
     node: () => ({
       background: '#ffffff',
     }),
@@ -22,6 +23,7 @@ function withDefaults(config: RunGraphConfig): RequiredGraphConfig {
     animationDuration: config.animationDuration ?? defaults.animationDuration,
     styles: {
       nodeHeight: config.styles?.nodeHeight ?? defaults.styles.nodeHeight,
+      nodeMargin: config.styles?.nodeMargin ?? defaults.styles.nodeMargin,
       node: node => ({
         ...defaults.styles.node(),
         ...config.styles?.node?.(node),

--- a/src/objects/config.ts
+++ b/src/objects/config.ts
@@ -7,8 +7,9 @@ let config: RequiredGraphConfig | null = null
 
 const defaults = {
   animationDuration: 200,
+  nodeRenderKey: (node) => `${node.kind},${node.start_time},${node.end_time},${node.state_type},${node.label}`,
   styles: {
-    nodeHeight: 20,
+    nodeHeight: 30,
     nodeMargin: 2,
     node: () => ({
       background: '#ffffff',
@@ -21,6 +22,7 @@ function withDefaults(config: RunGraphConfig): RequiredGraphConfig {
     runId: config.runId,
     fetch: config.fetch,
     animationDuration: config.animationDuration ?? defaults.animationDuration,
+    nodeRenderKey: config.nodeRenderKey ?? defaults.nodeRenderKey,
     styles: {
       nodeHeight: config.styles?.nodeHeight ?? defaults.styles.nodeHeight,
       nodeMargin: config.styles?.nodeMargin ?? defaults.styles.nodeMargin,

--- a/src/objects/index.ts
+++ b/src/objects/index.ts
@@ -4,6 +4,7 @@ import { startConfig, stopConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
 import { startFonts, stopFonts } from '@/objects/fonts'
 import { startNodes, stopNodes } from '@/objects/nodes'
+import { startNodesContainer, stopNodesContainer } from '@/objects/nodesContainer'
 import { startScales, stopScales } from '@/objects/scales'
 import { startScope, stopScope } from '@/objects/scope'
 import { startStage, stopStage } from '@/objects/stage'
@@ -28,6 +29,7 @@ export function start({ stage, props }: StartParameters): void {
   startFonts()
   startStage(stage)
   startConfig(props)
+  startNodesContainer()
 }
 
 export function stop(): void {
@@ -41,4 +43,5 @@ export function stop(): void {
   stopConfig()
   stopScope()
   stopFonts()
+  stopNodesContainer()
 }

--- a/src/objects/nodes.ts
+++ b/src/objects/nodes.ts
@@ -1,100 +1,177 @@
-import { BitmapText, Graphics } from 'pixi.js'
-import { RunGraphNode } from '@/models/RunGraph'
+import { BitmapText, Container, Graphics, IPointData } from 'pixi.js'
+import { RunGraphNode, RunGraphNodes } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
 import { waitForFonts } from '@/objects/fonts'
 import { waitForNodesContainer } from '@/objects/nodesContainer'
 import { waitForScales } from '@/objects/scales'
-import { centerViewport } from '@/objects/viewport'
 import { graphDataFactory } from '@/utilities/graphDataFactory'
 
 const { fetch: getData, stop: stopData } = graphDataFactory()
 
 type NodeSprites = {
-  graphics: Graphics,
+  nodeRenderKey: string,
+  container: Container,
   label: BitmapText,
+  box: Graphics,
 }
 
-const nodes = new Map<string, NodeSprites>()
-
-// dummy offset for now
-let yOffset = 0
+const nodeSprites = new Map<string, NodeSprites>()
 
 export async function startNodes(): Promise<void> {
   const config = await waitForConfig()
 
   getGraphData(config.runId)
 
-  emitter.on('configUpdated', config => getGraphData(config.runId))
-}
-
-export function stopNodes(): void {
-  nodes.clear()
-  yOffset = 0
-  stopData()
-}
-
-
-function getGraphData(runId: string): void {
-  getData(runId, async data => {
-    const promises: Promise<void>[] = []
-
-    data.nodes.forEach(node => {
-      promises.push(renderNode(node))
-    })
-
-    // once we get to "running" runs we'll want to only do this on the first load
-    await Promise.all(promises)
-    centerViewport()
+  emitter.on('configUpdated', () => {
+    stopNodes()
+    startNodes()
   })
 }
 
-async function renderNode(node: RunGraphNode): Promise<void> {
+export function stopNodes(): void {
+  nodeSprites.clear()
+  stopData()
+}
+
+async function getGraphData(runId: string): Promise<void> {
+  const nodesContainer = await waitForNodesContainer()
+
+  getData(runId, async data => {
+    await drawNodes(data.nodes)
+
+    // todo: calculate layout in worker after the nodes are drawn
+
+    nodeSprites.forEach(({ container }) => {
+
+      // this is just a wrong type IMO. there's no guarantee any pixi object has a parent
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!container.parent) {
+        nodesContainer.addChild(container)
+      }
+    })
+
+    // centerViewport()
+  })
+}
+
+async function drawNodes(nodes: RunGraphNodes): Promise<void> {
+  const promises: Promise<void>[] = []
+
+  nodes.forEach(node => {
+    promises.push(drawNode(node))
+  })
+
+  await Promise.all(promises)
+}
+
+async function drawNode(node: RunGraphNode): Promise<void> {
   const config = await waitForConfig()
-  const { scaleX, scaleY } = await waitForScales()
-  const { graphics, label } = nodes.get(node.id) ?? await createNode(node)
-  const { nodeMargin: margin } = config.styles
-  const { background } = config.styles.node(node)
+  const nodeRenderKey = config.nodeRenderKey(node)
+  const sprites = nodeSprites.get(node.id) ?? await createNode(node)
 
-  graphics.clear()
+  if (sprites.nodeRenderKey !== nodeRenderKey) {
+    await updateNode(node, sprites)
+  }
 
-  const offset = yOffset++
-  const x = scaleX(node.start_time)
-  const y = scaleY(offset) + margin
-  const width = scaleX(node.end_time ?? new Date()) - x
-  const height = scaleY(offset + 1) - y - margin
-
-  // graphics.lineStyle(1, 0x0, 1, 2)
-  graphics.beginFill(background)
-  graphics.drawRoundedRect(0, 0, width, height, 4)
-  graphics.endFill()
-
-  graphics.width = Math.max(width, 1)
-
-  graphics.position.set(x, y)
-  label.position.set(x + width + margin, y)
+  nodeSprites.set(node.id, sprites)
 }
 
 async function createNode(node: RunGraphNode): Promise<NodeSprites> {
-  const container = await waitForNodesContainer()
-  const { inter } = await waitForFonts()
+  const existing = nodeSprites.get(node.id)
+
+  if (existing) {
+    return existing
+  }
+
+  const config = await waitForConfig()
+  const nodeRenderKey = config.nodeRenderKey(node)
+
+  const box = await createNodeBox(node)
+  const label = await createNodeLabel(node)
+  const container = new Container()
+
+  label.position = await getLabelPositionRelativeToBox(label, box)
+
+  container.addChild(box)
+  container.addChild(label)
+
+  const sprites: NodeSprites = {
+    nodeRenderKey,
+    container,
+    label,
+    box,
+  }
+
+  return sprites
+}
+
+async function updateNode(node: RunGraphNode, sprites: NodeSprites): Promise<void> {
+  const box = await updateNodeBox(node, sprites.box)
+  const label = updateNodeLabel(node, sprites.label)
+
+  label.position = await getLabelPositionRelativeToBox(label, box)
+}
+
+async function createNodeBox(node: RunGraphNode): Promise<Graphics> {
   const graphics = new Graphics()
+
+  return await updateNodeBox(node, graphics)
+}
+
+async function updateNodeBox(node: RunGraphNode, box: Graphics): Promise<Graphics> {
+  box.clear()
+
+  const config = await waitForConfig()
+  const { scaleX } = await waitForScales()
+  const { background } = config.styles.node(node)
+
+  const boxLeft = scaleX(node.start_time)
+  const boxRight = scaleX(node.end_time ?? new Date())
+  const boxWidth = boxRight - boxLeft
+  const boxHeight = config.styles.nodeHeight - config.styles.nodeMargin * 2
+
+  box.beginFill(background)
+  box.drawRoundedRect(0, 0, boxWidth, boxHeight, 4)
+  box.endFill()
+
+  return box
+}
+
+async function createNodeLabel(node: RunGraphNode): Promise<BitmapText> {
+  const { inter } = await waitForFonts()
 
   const label = inter(node.label, {
     fontSize: 12,
   })
 
-  nodes.set(node.id, {
-    graphics,
-    label,
-  })
+  return label
+}
 
+function updateNodeLabel(node: RunGraphNode, label: BitmapText): BitmapText {
+  label.text = node.label
 
-  container.addChild(graphics)
-  container.addChild(label)
+  return label
+}
+
+async function getLabelPositionRelativeToBox(label: BitmapText, box: Graphics): Promise<IPointData> {
+  const config = await waitForConfig()
+
+  // todo: this should probably be nodePadding
+  const margin = config.styles.nodeMargin
+  const inside = box.width > margin + label.width + margin
+  // todo: this doesn't look quite right
+  const y = box.height / 2 - label.height / 2
+
+  if (inside) {
+    return {
+      x: margin,
+      y,
+    }
+  }
 
   return {
-    graphics,
-    label,
+    x: box.width + margin,
+    y,
   }
 }

--- a/src/objects/nodes.ts
+++ b/src/objects/nodes.ts
@@ -89,7 +89,7 @@ async function createNode(node: RunGraphNode): Promise<NodeSprites> {
 
   const box = await createNodeBox(node)
   const label = await createNodeLabel(node)
-  const container = new Container()
+  const container = createContainer()
 
   label.position = await getLabelPositionRelativeToBox(label, box)
 
@@ -111,6 +111,14 @@ async function updateNode(node: RunGraphNode, sprites: NodeSprites): Promise<voi
   const label = updateNodeLabel(node, sprites.label)
 
   label.position = await getLabelPositionRelativeToBox(label, box)
+}
+
+function createContainer(): Container {
+  const container = new Container()
+
+  container.eventMode = 'none'
+
+  return container
 }
 
 async function createNodeBox(node: RunGraphNode): Promise<Graphics> {

--- a/src/objects/nodesContainer.ts
+++ b/src/objects/nodesContainer.ts
@@ -1,0 +1,26 @@
+import { Container } from 'pixi.js'
+import { emitter, waitForEvent } from '@/objects/events'
+import { waitForViewport } from '@/objects/viewport'
+
+let container: Container | null = null
+
+export async function startNodesContainer(): Promise<void> {
+  const viewport = await waitForViewport()
+  container = new Container()
+
+  viewport.addChild(container)
+
+  emitter.emit('containerCreated', container)
+}
+
+export function stopNodesContainer(): void {
+  container = null
+}
+
+export async function waitForNodesContainer(): Promise<Container> {
+  if (container) {
+    return container
+  }
+
+  return await waitForEvent('containerCreated')
+}

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -54,7 +54,6 @@ export async function centerViewport({ animate }: CenterViewportParameters = {})
   const container = await waitForContainer()
   const config = await waitForConfig()
 
-
   // when we get to culling we might need to turn it off for this measurement
   const { x, y, width, height } = container.getLocalBounds()
   const scale = viewport.findFit(width, height)

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -5,7 +5,7 @@ import { RunGraphProps } from '@/models/RunGraph'
 import { waitForApplication } from '@/objects/application'
 import { waitForConfig } from '@/objects/config'
 import { emitter, waitForEvent } from '@/objects/events'
-import { waitForContainer } from '@/objects/nodes'
+import { waitForNodesContainer } from '@/objects/nodesContainer'
 import { ScaleXDomain, waitForScales } from '@/objects/scales'
 import { waitForScope } from '@/objects/scope'
 import { waitForStage } from '@/objects/stage'
@@ -51,7 +51,7 @@ type CenterViewportParameters = {
 
 export async function centerViewport({ animate }: CenterViewportParameters = {}): Promise<void> {
   const viewport = await waitForViewport()
-  const container = await waitForContainer()
+  const container = await waitForNodesContainer()
   const config = await waitForConfig()
 
   // when we get to culling we might need to turn it off for this measurement


### PR DESCRIPTION
# Description
This is a bit of a pivot prior to implementing the actual layout worker. In the v1 we first send the nodes to the layout worker, calculate the layout, then we render. This means that we don't actually know the size of individual nodes because we don't know if the label fits inside the box or not. So we calculate the do the box and label calculations inside the worker. This is a little problematic because we don't actually know the width of the label at this point. So we calculate it based on the label's length multiplied by a approximate character width. All this is done in the worker when calculating the layout. 

What this PR starts implementing is breaking apart the rendering of nodes and the positioning of nodes. So rather than
- Get nodes data
- Calculate layout (in worker)
- Render, position, and add nodes to the canvas

We'll end up with
- Get nodes data
- Render nodes (but don't add them to the canvas yet!)
- Calculate layout (in worker, based on actual size of nodes)
- position and add nodes to the canvas

I believe this will simplify the layout complexity. It becomes "figure out where the nodes go" rather than "figure out the size of the nodes and figure out where they go".

I also think this means the layouts can be determined independent of the type of scales. This would mean that we could possibly reuse the "nearest parent" layout when rendering a run in a DAG like layout. The layout can just care about x,y and not care about dates. 

## Note about `nodeRenderKey`s
I also added the concept of "render keys" in this PR. Essentially, when rendering a node we can check if the rendering we already have is what we're going to end up with. So we can skip rendering and reuse what has already been rendered. If the key does not match, the existing pixi objects are updated rather than being recreated. I believe this will increase performance when viewing graphs where the root node (flow run, task run) is "running".

## Deployment preview missing layout
While pivoting I removed the temporary waterfall layout that was built into the nodes object. That will get re-added in the next PR in the layout worker. 