### PR TITLE
Add center and fullscreen actions

### DIFF
--- a/src/components/RunGraph.vue
+++ b/src/components/RunGraph.vue
@@ -1,22 +1,48 @@
 <template>
-  <div ref="stage" class="run-graph" />
+  <div class="run-graph" :class="classes.root">
+    <div ref="stage" class="run-graph__stage" />
+    <div class="run-graph__actions">
+      <p-button title="Recenter Timeline" icon="Target" flat @click="() => centerViewport({ animate: true })" />
+      <p-button title="View Timeline in Fullscreen" icon="ArrowsPointingOutIcon" flat @click="toggleFullscreen" />
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
-  import { onBeforeUnmount, onMounted, ref } from 'vue'
+  import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
   import { RunGraphProps } from '@/models/RunGraph'
-  import { ScaleXDomain, start, stop } from '@/objects'
+  import { ScaleXDomain, start, stop, centerViewport } from '@/objects'
   import { emitter } from '@/objects/events'
 
   // using the props object as a whole
   // eslint-disable-next-line vue/no-unused-properties
-  const props = defineProps<RunGraphProps>()
+  const props = withDefaults(defineProps<RunGraphProps>(), {
+    fullscreen: null,
+  })
 
   const emit = defineEmits<{
     (event: 'update:viewport', value: ScaleXDomain): void,
+    (event: 'update:fullscreen', value: boolean): void,
   }>()
 
   const stage = ref<HTMLDivElement>()
+
+  const fullscreenInternal = ref(false)
+  const fullscreenModel = computed({
+    get() {
+      return props.fullscreen ?? fullscreenInternal.value
+    },
+    set(value) {
+      fullscreenInternal.value = value
+      emit('update:fullscreen', value)
+    },
+  })
+
+  const classes = computed(() => ({
+    root: {
+      'run-graph--fullscreen': fullscreenModel.value,
+    },
+  }))
 
   emitter.on('viewportDateRangeUpdated', range => emit('update:viewport', range))
   // emitter.on('domainUpdated', domain => emit('update:domain', domain))
@@ -33,6 +59,10 @@
   //       throw new Error(`data.type does not have a handler associated with it: ${exhaustive}`)
   //   }
   // }
+
+  function toggleFullscreen(): void {
+    fullscreenModel.value = !fullscreenModel.value
+  }
 
   onMounted(() => {
     if (!stage.value) {
@@ -51,8 +81,28 @@
 </script>
 
 <style>
-.run-graph > canvas {
+.run-graph {
+  position: relative;
+}
+
+.run-graph--fullscreen {
+  position: fixed;
+  height: 100vh !important;
+  width: 100vw !important;
+  left: 0;
+  top: 0;
+}
+
+.run-graph__stage,
+.run-graph__stage > canvas {
   width: 100%;
   height: 100%;
+}
+
+.run-graph__actions {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  padding: theme('spacing.2');
 }
 </style>

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -6,6 +6,7 @@ import { ScaleXDomain } from '@/objects'
 export type RunGraphProps = {
   config: RunGraphConfig,
   viewport?: ScaleXDomain,
+  fullscreen?: boolean | null,
 }
 
 export type RunGraphData = {

--- a/src/objects/config.ts
+++ b/src/objects/config.ts
@@ -6,7 +6,7 @@ import { waitForScope } from '@/objects/scope'
 let config: RequiredGraphConfig | null = null
 
 const defaults = {
-  animationDuration: 200,
+  animationDuration: 500,
   nodeRenderKey: (node) => `${node.id},${node.kind},${node.start_time},${node.end_time},${node.state_type},${node.label}`,
   styles: {
     nodeHeight: 30,

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -37,6 +37,7 @@ export async function startViewport(props: RunGraphProps): Promise<void> {
   application.stage.addChild(viewport)
 
   emitter.emit('viewportCreated', viewport)
+  emitter.on('stageUpdated', resizeViewport)
 
   watchVisibleDateRange(props)
   startViewportDateRange()
@@ -122,4 +123,14 @@ async function updateViewportDateRange(): Promise<void> {
   const right = scaleX.invert(viewport.right)
 
   setViewportDateRange([left, right])
+}
+
+async function resizeViewport(): Promise<void> {
+  if (!viewport) {
+    return
+  }
+
+  const application = await waitForApplication()
+
+  viewport.resize(application.screen.width, application.screen.height)
 }


### PR DESCRIPTION
# Description
Adds the center and fullscreen actions directly to the RunGraph component. Previously these were implementation details in ui-library. But I think it makes sense to have these built in. 

The settings icon to switch layouts will get added later. I also didn't wire up the keyboard shortcuts yet

<img width="990" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/f1f98e6a-5bcf-42a0-a1ce-8721ad3f03ae">
