### PR TITLE
Add core functionality for adding "bumps" to a specific axis

### DIFF
--- a/src/utilities/axisBumpFactory.ts
+++ b/src/utilities/axisBumpFactory.ts
@@ -1,0 +1,68 @@
+// Map<YAxis, Map<NodeId, offset>>
+type AxisBumps = Map<number, Map<string, number> | undefined>
+
+type SetBumpParameters = {
+  axis: number,
+  nodeId: string,
+  offset: number,
+}
+
+type RemoveBumpParameters = {
+  axis: number,
+  nodeId: string,
+}
+
+type BumpFactory = {
+  get: (axis: number) => number,
+  set: (value: SetBumpParameters) => void,
+  delete: (value: RemoveBumpParameters) => void,
+  bump: (axis: number) => number,
+  clear: () => void,
+}
+
+export function axisBumpFactory(): BumpFactory {
+  const bumps: AxisBumps = new Map()
+
+  const get: BumpFactory['get'] = (axis) => {
+    const values = bumps.get(axis)
+
+    if (!values) {
+      return 0
+    }
+
+    return Math.max(...values.values())
+  }
+
+  const set: BumpFactory['set'] = ({ axis, nodeId, offset }) => {
+    const value = bumps.get(axis) ?? new Map<string, number>()
+
+    value.set(nodeId, offset)
+    bumps.set(axis, value)
+  }
+
+  const remove: BumpFactory['delete'] = ({ axis, nodeId }) => {
+    bumps.get(axis)?.delete(nodeId)
+  }
+
+  const bump: BumpFactory['bump'] = (axis) => {
+    let value = 0
+
+    for (let index = 1; index <= axis; index++) {
+      value += get(index)
+    }
+
+    return value
+  }
+
+  const clear: BumpFactory['clear'] = () => {
+    bumps.clear()
+  }
+
+  return {
+    get,
+    set,
+    delete: remove,
+    bump,
+    clear,
+  }
+}


### PR DESCRIPTION
# Description
First off "bump" is a terribly nondescript word to describe this. Buts Friday and my brain is about empty 🙃 hopefully a better name will reveal itself.

Okay, what are bumps and why do we need them? Great question

Sub flow runs are rendered on the graph as individual nodes that can be expanded to see the run graph for that sub flow run. When a sub flow is expanded, the parent run graph needs to expand and make room for it. This means some nodes need to move out of the way. 
<img width="846" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/45b1a250-9881-45cf-97d9-437c42647305">
<img width="758" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/f2a11948-2029-4cef-a970-c6339aa8627e">

To understand this its important to remember that x,y on the scales/layout is not a 1:1 with the x,y position on the canvas. The x position is so far the same but the y axis is used to calculate the final y position on the canvas based on the node height and "bumps".

"bumps" are a way for an individual node to inform the layout that it needs some extra space. A node can add/remove a bump with a given value. Meaning a sub flow at 0,10 on the axes can inform the layout that it needs extra space by doing `bumps.set({ axis: 10, nodeId: 'foo', offset: 100 })` which means the node `foo` on the y axis `10` needs an additional `100` pixels of space in order to fit. 

Every node that is on a greater axis (y11+ in this example) will move down by `100` pixels from where it would normally be positioned, leaving room for the expanded node on y10