### PR TITLE
Remove centering logic from `NodesContainerService` and little cleanup

### DIFF
--- a/src/objects/events.ts
+++ b/src/objects/events.ts
@@ -7,6 +7,7 @@ import { RequiredGraphConfig } from '@/models/RunGraph'
 import { ViewportDateRange } from '@/models/viewport'
 import { Fonts } from '@/objects/fonts'
 import { NodePositionService } from '@/services/nodePositionService'
+import { NodesContainerService } from '@/services/nodesContainerService'
 
 type Events = {
   scalesCreated: NodePositionService,
@@ -23,6 +24,7 @@ type Events = {
   fontsLoaded: Fonts,
   containerCreated: Container,
   layoutUpdated: LayoutMode,
+  nodesCreated: NodesContainerService,
 }
 
 export type EventKey = keyof Events

--- a/src/objects/nodes.ts
+++ b/src/objects/nodes.ts
@@ -1,3 +1,4 @@
+import { Ticker } from 'pixi.js'
 import { waitForConfig } from '@/objects/config'
 import { centerViewport, waitForViewport } from '@/objects/viewport'
 import { NodesContainerService } from '@/services/nodesContainerService'
@@ -13,9 +14,24 @@ export async function startNodes(): Promise<void> {
     parent: viewport,
   })
 
+  service.container.alpha = 0
+
   const center = (): void => {
+    if (!service) {
+      return
+    }
+
     centerViewport()
-    service?.emitter.off('rendered', center)
+
+    Ticker.shared.addOnce(() => {
+      if (!service) {
+        return
+      }
+
+      service.container.alpha = 1
+    })
+
+    service.emitter.off('rendered', center)
   }
 
   service.emitter.on('rendered', center)

--- a/src/objects/nodes.ts
+++ b/src/objects/nodes.ts
@@ -1,5 +1,5 @@
 import { waitForConfig } from '@/objects/config'
-import { waitForViewport } from '@/objects/viewport'
+import { centerViewport, waitForViewport } from '@/objects/viewport'
 import { NodesContainerService } from '@/services/nodesContainerService'
 
 let service: NodesContainerService | null = null
@@ -12,6 +12,13 @@ export async function startNodes(): Promise<void> {
     runId: config.runId,
     parent: viewport,
   })
+
+  const center = (): void => {
+    centerViewport()
+    service?.emitter.off('rendered', center)
+  }
+
+  service.emitter.on('rendered', center)
 }
 
 export function stopNodes(): void {

--- a/src/services/containerService.ts
+++ b/src/services/containerService.ts
@@ -1,8 +1,16 @@
 import { Container } from 'pixi.js'
 import { Pixels } from '@/models/layout'
 
+type ContainerServiceParameters = {
+  parent: Container,
+}
+
 export class ContainerService {
   public container = new Container()
+
+  public constructor(parameters: ContainerServiceParameters) {
+    parameters.parent.addChild(this.container)
+  }
 
   public get position(): Pixels {
     return this.container.position

--- a/src/services/nodeFlowRunService.ts
+++ b/src/services/nodeFlowRunService.ts
@@ -20,7 +20,7 @@ export class NodeFlowRunService extends ContainerService implements NodeRenderSe
   private readonly label: NodeLabelService
 
   public constructor(parameters: NodeTaskRunServiceParameters) {
-    super()
+    super(parameters)
 
     this.positionService = parameters.positionService
     this.container.name = DEFAULT_NODE_CONTAINER_NAME
@@ -34,8 +34,6 @@ export class NodeFlowRunService extends ContainerService implements NodeRenderSe
     this.label = new NodeLabelService({
       parent: this.container,
     })
-
-    parameters.parent.addChild(this.container)
   }
 
   public async render(node: RunGraphNode): Promise<Container> {

--- a/src/services/nodeOffsetService.ts
+++ b/src/services/nodeOffsetService.ts
@@ -22,7 +22,7 @@ export class NodeOffsetService {
       return 0
     }
 
-    return Math.max(...values.values())
+    return Math.max(...values.values(), 0)
   }
 
   public getTotalOffset(axis: number): number {

--- a/src/services/nodeTaskRunService.ts
+++ b/src/services/nodeTaskRunService.ts
@@ -20,7 +20,7 @@ export class NodeTaskRunService extends ContainerService implements NodeRenderSe
   private readonly label: NodeLabelService
 
   public constructor(parameters: NodeTaskRunServiceParameters) {
-    super()
+    super(parameters)
 
     this.positionService = parameters.positionService
     this.container.eventMode = 'none'
@@ -35,8 +35,6 @@ export class NodeTaskRunService extends ContainerService implements NodeRenderSe
     this.label = new NodeLabelService({
       parent: this.container,
     })
-
-    parameters.parent.addChild(this.container)
   }
 
   public async render(node: RunGraphNode): Promise<Container> {

--- a/src/services/nodesContainerService.ts
+++ b/src/services/nodesContainerService.ts
@@ -1,10 +1,10 @@
+import mitt from 'mitt'
 import { Container } from 'pixi.js'
 import { DEFAULT_NODES_CONTAINER_NAME, DEFAULT_POLL_INTERVAL } from '@/consts'
 import { GraphPostLayout, GraphPreLayout, NodePreLayout } from '@/models/layout'
 import { RunGraphNode, RunGraphNodes } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
 import { layout } from '@/objects/layout'
-import { centerViewport } from '@/objects/viewport'
 import { ContainerService } from '@/services/containerService'
 import { NodeContainerService } from '@/services/nodeContainerService'
 import { NodePositionService } from '@/services/nodePositionService'
@@ -16,6 +16,13 @@ type NodeParameters = {
   parent: Container,
 }
 
+type NodesContainerEvents = {
+  rendered: void,
+}
+
+
+export class NodesContainerService extends ContainerService {
+  public readonly emitter = mitt<NodesContainerEvents>()
 export class NodesContainerService extends ContainerService {
   private readonly runId: string
   private readonly worker = layoutWorkerFactory(this.onLayoutWorkerMessage.bind(this))
@@ -105,8 +112,7 @@ export class NodesContainerService extends ContainerService {
       objects.node.visible = true
     })
 
-    // this should only happen on the first layout
-    centerViewport()
+    this.emitter.emit('rendered')
   }
 
   private onLayoutWorkerMessage({ data }: MessageEvent<WorkerMessage>): void {


### PR DESCRIPTION
# Description
- Fixes a `todo` where the `NodesContainerService` centered the viewport after each render.
- Fixes a bug in the `NodeOffsetService` where `-infinity` would be returned for an axis with no offsets. 
- Implements `ContainerService` in `NodesContainerService`
- Has `ContainerService` add itself to the parent like other pixi object services
- Consistent naming of `positionService`