### PR TITLE
Render sub flow runs

### DIFF
--- a/src/factories/flowRun.ts
+++ b/src/factories/flowRun.ts
@@ -6,6 +6,8 @@ import { Pixels } from '@/models/layout'
 import { RunGraphNode } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
 
+export type FlowRunContainer = Awaited<ReturnType<typeof flowRunContainerFactory>>
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function flowRunContainerFactory() {
   const container = new Container()
@@ -50,6 +52,7 @@ export async function flowRunContainerFactory() {
   }
 
   return {
+    kind: 'flow-run' as const,
     container,
     render,
   }

--- a/src/factories/flowRun.ts
+++ b/src/factories/flowRun.ts
@@ -10,21 +10,24 @@ import { waitForConfig } from '@/objects/config'
 export type FlowRunContainer = Awaited<ReturnType<typeof flowRunContainerFactory>>
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export async function flowRunContainerFactory() {
+export async function flowRunContainerFactory(node: RunGraphNode) {
   const container = new Container()
   const { label, render: renderLabel } = await nodeLabelFactory()
   const { box, render: renderBox } = await nodeBoxFactory()
+  const { container: nodesContainer, render: renderNodes } = await nodesContainerFactory(node.id)
 
   let open = false
 
   container.addChild(box)
   container.addChild(label)
+  container.addChild(nodesContainer)
 
   container.name = DEFAULT_NODE_CONTAINER_NAME
   container.eventMode = 'static'
   container.cursor = 'pointer'
 
   container.on('click', toggle)
+  nodesContainer.on('resized', () => container.emit('resized'))
 
   async function render(node: RunGraphNode): Promise<Container> {
     const label = await renderLabel(node)
@@ -39,17 +42,10 @@ export async function flowRunContainerFactory() {
     open = !open
 
     if (open) {
-      drawNodes()
+      renderNodes()
     }
 
     container.emit('resized')
-  }
-
-  async function drawNodes(): Promise<void> {
-    const nodes = await nodesContainerFactory('foo')
-    container.addChild(nodes.container)
-
-    nodes.container.on('rendered', () => container.emit('resized'))
   }
 
   async function getLabelPosition(label: BitmapText, box: Graphics): Promise<Pixels> {

--- a/src/factories/flowRun.ts
+++ b/src/factories/flowRun.ts
@@ -44,8 +44,6 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     if (open) {
       renderNodes()
     }
-
-    container.emit('resized')
   }
 
   async function getLabelPosition(label: BitmapText, box: Graphics): Promise<Pixels> {

--- a/src/factories/flowRun.ts
+++ b/src/factories/flowRun.ts
@@ -2,6 +2,7 @@ import { BitmapText, Container, Graphics } from 'pixi.js'
 import { DEFAULT_NODE_CONTAINER_NAME } from '@/consts'
 import { nodeBoxFactory } from '@/factories/box'
 import { nodeLabelFactory } from '@/factories/label'
+import { nodesContainerFactory } from '@/factories/nodes'
 import { Pixels } from '@/models/layout'
 import { RunGraphNode } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
@@ -36,7 +37,19 @@ export async function flowRunContainerFactory() {
 
   function toggle(): void {
     open = !open
+
+    if (open) {
+      drawNodes()
+    }
+
     container.emit('resized')
+  }
+
+  async function drawNodes(): Promise<void> {
+    const nodes = await nodesContainerFactory('foo')
+    container.addChild(nodes.container)
+
+    nodes.container.on('rendered', () => container.emit('resized'))
   }
 
   async function getLabelPosition(label: BitmapText, box: Graphics): Promise<Pixels> {

--- a/src/factories/flowRun.ts
+++ b/src/factories/flowRun.ts
@@ -14,12 +14,16 @@ export async function flowRunContainerFactory() {
   const { label, render: renderLabel } = await nodeLabelFactory()
   const { box, render: renderBox } = await nodeBoxFactory()
 
+  let open = false
+
   container.addChild(box)
   container.addChild(label)
 
   container.name = DEFAULT_NODE_CONTAINER_NAME
   container.eventMode = 'static'
   container.cursor = 'pointer'
+
+  container.on('click', toggle)
 
   async function render(node: RunGraphNode): Promise<Container> {
     const label = await renderLabel(node)
@@ -28,6 +32,11 @@ export async function flowRunContainerFactory() {
     label.position = await getLabelPosition(label, box)
 
     return container
+  }
+
+  function toggle(): void {
+    open = !open
+    container.emit('resized')
   }
 
   async function getLabelPosition(label: BitmapText, box: Graphics): Promise<Pixels> {

--- a/src/factories/node.ts
+++ b/src/factories/node.ts
@@ -33,7 +33,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
       case 'task-run':
         return await taskRunContainerFactory()
       case 'flow-run':
-        return await flowRunContainerFactory()
+        return await flowRunContainerFactory(node)
       default:
         const exhaustive: never = kind
         throw new Error(`switch does not have case for value: ${exhaustive}`)

--- a/src/factories/node.ts
+++ b/src/factories/node.ts
@@ -1,6 +1,6 @@
 import { Container, Ticker } from 'pixi.js'
-import { flowRunContainerFactory } from '@/factories/flowRun'
-import { taskRunContainerFactory } from '@/factories/taskRun'
+import { FlowRunContainer, flowRunContainerFactory } from '@/factories/flowRun'
+import { TaskRunContainer, taskRunContainerFactory } from '@/factories/taskRun'
 import { RunGraphNode } from '@/models/RunGraph'
 
 export type NodeContainerFactory = Awaited<ReturnType<typeof nodeContainerFactory>>
@@ -26,8 +26,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
     return container
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  async function getNodeFactory(node: RunGraphNode) {
+  async function getNodeFactory(node: RunGraphNode): Promise<TaskRunContainer | FlowRunContainer> {
     const { kind } = node
 
     switch (kind) {

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -71,7 +71,7 @@ export async function nodesContainerFactory(runId: string) {
     return await render(node)
   }
 
-  function updateLayout(): void {
+  function setPositions(): void {
     layout.forEach((position, nodeId) => {
       const node = nodes.get(nodeId)
 
@@ -95,10 +95,28 @@ export async function nodesContainerFactory(runId: string) {
 
     const response = await nodeContainerFactory(node)
 
+    response.container.on('resized', () => offset(node.id))
+
     nodes.set(node.id, response)
     container.addChild(response.container)
 
     return response
+  }
+
+  function offset(nodeId: string): void {
+    const node = nodes.get(nodeId)
+    const nodeLayout = layout.get(nodeId)
+
+    if (!node || !nodeLayout) {
+      return
+    }
+
+    const axis = nodeLayout.y
+    const offset = 100
+
+    offsets.setOffset({ axis, nodeId, offset })
+
+    setPositions()
   }
 
   function getActualPosition(position: Pixels): Pixels {
@@ -127,7 +145,7 @@ export async function nodesContainerFactory(runId: string) {
     // eslint-disable-next-line prefer-destructuring
     layout = data.layout
 
-    updateLayout()
+    setPositions()
   }
 
   return {

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -25,21 +25,19 @@ export async function nodesContainerFactory(runId: string) {
 
   container.name = DEFAULT_NODES_CONTAINER_NAME
 
-  fetch()
-
-  async function fetch(): Promise<void> {
+  async function render(): Promise<void> {
     const data = await config.fetch(runId)
 
     settings = horizontalSettingsFactory(data.start_time)
 
-    await render(data.nodes)
+    await renderNodes(data.nodes)
 
     if (!data.end_time) {
-      setTimeout(() => fetch(), DEFAULT_POLL_INTERVAL)
+      setTimeout(() => render(), DEFAULT_POLL_INTERVAL)
     }
   }
 
-  async function render(nodes: RunGraphNodes): Promise<void> {
+  async function renderNodes(nodes: RunGraphNodes): Promise<void> {
     const request: NodeLayoutRequest = new Map()
 
     for (const [nodeId, node] of nodes) {
@@ -77,6 +75,7 @@ export async function nodesContainerFactory(runId: string) {
       node.container.position = getActualPosition(position)
     })
 
+    container.emit('resized')
     container.emit('rendered')
   }
 
@@ -144,5 +143,6 @@ export async function nodesContainerFactory(runId: string) {
 
   return {
     container,
+    render,
   }
 }

--- a/src/factories/offsets.ts
+++ b/src/factories/offsets.ts
@@ -27,7 +27,7 @@ export async function offsetsFactory() {
   function getTotalOffset(axis: number): number {
     let value = 0
 
-    for (let index = 1; index < axis; index++) {
+    for (let index = 0; index < axis; index++) {
       value += getOffset(index)
     }
 

--- a/src/factories/offsets.ts
+++ b/src/factories/offsets.ts
@@ -12,7 +12,6 @@ type RemoveOffsetParameters = {
 }
 
 export type Offsets = Awaited<ReturnType<typeof offsetsFactory>>
-export type OffsetFactory = Offsets['factory']
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function offsetsFactory() {
@@ -51,22 +50,11 @@ export async function offsetsFactory() {
     offsets.clear()
   }
 
-  function factory({ axis, nodeId }: Omit<SetOffsetParameters, 'offset'>) {
-    return (offset: number) => {
-      if (offset > 0) {
-        setOffset({ axis, nodeId, offset })
-      } else {
-        removeOffset({ axis, nodeId })
-      }
-    }
-  }
-
   return {
     getOffset,
     getTotalOffset,
     setOffset,
     removeOffset,
     clear,
-    factory,
   }
 }

--- a/src/factories/taskRun.ts
+++ b/src/factories/taskRun.ts
@@ -6,6 +6,8 @@ import { Pixels } from '@/models/layout'
 import { RunGraphNode } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
 
+export type TaskRunContainer = Awaited<ReturnType<typeof taskRunContainerFactory>>
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function taskRunContainerFactory() {
   const container = new Container()
@@ -49,6 +51,7 @@ export async function taskRunContainerFactory() {
   }
 
   return {
+    kind: 'task-run' as const,
     render,
     container,
   }

--- a/src/objects/events.ts
+++ b/src/objects/events.ts
@@ -2,7 +2,6 @@ import { Viewport } from 'pixi-viewport'
 import { Application, Container } from 'pixi.js'
 import { EffectScope } from 'vue'
 import { eventsFactory } from '@/factories/events'
-import { NodesContainer } from '@/factories/nodes'
 import { HorizontalScale } from '@/factories/position'
 import { LayoutMode } from '@/models/layout'
 import { RequiredGraphConfig } from '@/models/RunGraph'
@@ -24,7 +23,6 @@ type Events = {
   fontsLoaded: Fonts,
   containerCreated: Container,
   layoutUpdated: LayoutMode,
-  nodesCreated: NodesContainer,
 }
 
 export type EventKey = keyof Events

--- a/src/objects/nodes.ts
+++ b/src/objects/nodes.ts
@@ -1,7 +1,6 @@
 import { Ticker } from 'pixi.js'
 import { NodesContainer, nodesContainerFactory } from '@/factories/nodes'
 import { waitForConfig } from '@/objects/config'
-import { emitter, waitForEvent } from '@/objects/events'
 import { centerViewport, waitForViewport } from '@/objects/viewport'
 
 let nodes: NodesContainer | null = null
@@ -16,21 +15,13 @@ export async function startNodes(): Promise<void> {
 
   nodes.container.alpha = 0
 
-  nodes.container.once('rendered', center)
+  nodes.render()
 
-  emitter.emit('nodesCreated', nodes)
+  nodes.container.once('rendered', center)
 }
 
 export function stopNodes(): void {
   nodes = null
-}
-
-export async function waitForNodes(): Promise<NodesContainer> {
-  if (nodes) {
-    return nodes
-  }
-
-  return await waitForEvent('nodesCreated')
 }
 
 function center(): void {

--- a/src/objects/nodes.ts
+++ b/src/objects/nodes.ts
@@ -16,7 +16,7 @@ export async function startNodes(): Promise<void> {
 
   nodes.container.alpha = 0
 
-  nodes.events.once('rendered', center)
+  nodes.container.once('rendered', center)
 
   emitter.emit('nodesCreated', nodes)
 }

--- a/src/pixi.d.ts
+++ b/src/pixi.d.ts
@@ -1,5 +1,6 @@
 declare namespace GlobalMixins {
   interface DisplayObjectEvents {
     resized: [],
+    rendered: [],
   }
 }

--- a/src/pixi.d.ts
+++ b/src/pixi.d.ts
@@ -1,0 +1,5 @@
+declare namespace GlobalMixins {
+  interface DisplayObjectEvents {
+    resized: [],
+  }
+}


### PR DESCRIPTION
# Description
Clicking on a flow run on the graph will the flow run on the graph. Bumping other content out of the way. 

For now it just renders right on to of the flow run that was clicked on and you cannot collapse it. 

WIP PR to try and keep things a little smaller. 

The last node in the demo is a flow run. Clicking on it will render another demo flow on the graph. 

<img width="912" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/1fb58de0-30d5-4cc1-b880-e54b648be302">
