### PR TITLE
Allow user to set the view to trace or dependency

### DIFF
--- a/src/components/RunGraph.vue
+++ b/src/components/RunGraph.vue
@@ -4,12 +4,14 @@
     <div class="run-graph__actions">
       <p-button title="Recenter Timeline" icon="Target" flat @click="() => centerViewport({ animate: true })" />
       <p-button title="View Timeline in Fullscreen" icon="ArrowsPointingOutIcon" flat @click="toggleFullscreen" />
+      <RunGraphSettings />
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
   import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+  import RunGraphSettings from '@/components/RunGraphSettings.vue'
   import { RunGraphProps } from '@/models/RunGraph'
   import { ViewportDateRange } from '@/models/viewport'
   import { start, stop, centerViewport } from '@/objects'

--- a/src/components/RunGraphSettings.vue
+++ b/src/components/RunGraphSettings.vue
@@ -1,0 +1,100 @@
+<template>
+  <p-pop-over
+    class="run-graph-settings"
+    auto-close
+    :placement="placement"
+  >
+    <template #target="{ toggle }">
+      <p-button
+        aria-label="Run Graph Options"
+        icon="CogIcon"
+        flat
+        @click="toggle"
+      />
+    </template>
+
+    <p-overflow-menu class="run-graph-settings__menu">
+      <p-label label="View">
+        <p-radio-group v-model="horizontal" :options="horizontalOptions">
+          <template #label="{ option }">
+            {{ option.label }}
+          </template>
+        </p-radio-group>
+      </p-label>
+      <p-label label="Layout">
+        <p-radio-group v-model="vertical" :options="verticalOptions" disabled>
+          <template #label="{ option }">
+            {{ option.label }}
+          </template>
+        </p-radio-group>
+      </p-label>
+    </p-overflow-menu>
+  </p-pop-over>
+</template>
+
+<script lang="ts" setup>
+  import { PButton, positions, PPopOver } from '@prefecthq/prefect-design'
+  import { computed } from 'vue'
+  import { HorizontalMode, VerticalMode } from '@/models/layout'
+  import { layout, setHorizontalMode, setVerticalMode } from '@/objects/layout'
+
+  type Option<T extends string> = {
+    value: T,
+    label: string,
+  }
+
+  const placement = [positions.topRight, positions.bottomRight, positions.topLeft, positions.bottomLeft]
+
+  const horizontalOptions: Option<HorizontalMode>[] = [
+    {
+      value: 'dependency',
+      label: 'Dependency',
+    },
+    {
+      value: 'trace',
+      label: 'Trace',
+    },
+  ]
+
+  const horizontal = computed({
+    get() {
+      return layout.horizontal
+    },
+    set(value) {
+      setHorizontalMode(value)
+    },
+  })
+
+  const verticalOptions: Option<VerticalMode>[] = [
+    {
+      value: 'waterfall',
+      label: 'Waterfall',
+    },
+    {
+      value: 'nearest-parent',
+      label: 'Nearest Parent',
+    },
+  ]
+
+  const vertical = computed({
+    get() {
+      return layout.vertical
+    },
+    set(value) {
+      setVerticalMode(value)
+    },
+  })
+</script>
+
+<style>
+.run-graph-settings {
+  display: inline-block;
+}
+
+.run-graph-settings__menu {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: theme('spacing.4');
+  padding: theme('spacing.2');
+}
+</style>

--- a/src/factories/box.ts
+++ b/src/factories/box.ts
@@ -1,8 +1,9 @@
 import { differenceInMilliseconds, millisecondsInSecond } from 'date-fns'
 import { Graphics } from 'pixi.js'
-import { DEFAULT_TIME_COLUMN_SIZE_PIXELS } from '@/consts'
+import { DEFAULT_LINEAR_COLUMN_SIZE_PIXELS, DEFAULT_TIME_COLUMN_SIZE_PIXELS } from '@/consts'
 import { RunGraphNode } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
+import { layout } from '@/objects/layout'
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function nodeBoxFactory() {
@@ -12,19 +13,29 @@ export async function nodeBoxFactory() {
   async function render(node: RunGraphNode): Promise<Graphics> {
     const { background } = config.styles.node(node)
 
-    const right = node.start_time
-    const left = node.end_time ?? new Date()
-    const seconds = differenceInMilliseconds(left, right) / millisecondsInSecond
-    const boxWidth = seconds * DEFAULT_TIME_COLUMN_SIZE_PIXELS
-    const boxHeight = config.styles.nodeHeight - config.styles.nodeMargin * 2
+    const width = getWidth(node)
+    const height = config.styles.nodeHeight - config.styles.nodeMargin * 2
 
     box.clear()
     box.lineStyle(1, 0x0, 1, 2)
     box.beginFill(background)
-    box.drawRoundedRect(0, 0, boxWidth, boxHeight, 4)
+    box.drawRoundedRect(0, 0, width, height, 4)
     box.endFill()
 
     return await box
+  }
+
+  function getWidth(node: RunGraphNode): number {
+    if (layout.horizontal === 'time') {
+      const right = node.start_time
+      const left = node.end_time ?? new Date()
+      const seconds = differenceInMilliseconds(left, right) / millisecondsInSecond
+      const width = seconds * DEFAULT_TIME_COLUMN_SIZE_PIXELS
+
+      return width
+    }
+
+    return DEFAULT_LINEAR_COLUMN_SIZE_PIXELS
   }
 
   return {

--- a/src/factories/box.ts
+++ b/src/factories/box.ts
@@ -26,7 +26,7 @@ export async function nodeBoxFactory() {
   }
 
   function getWidth(node: RunGraphNode): number {
-    if (layout.horizontal === 'time') {
+    if (layout.horizontal === 'trace') {
       const right = node.start_time
       const left = node.end_time ?? new Date()
       const seconds = differenceInMilliseconds(left, right) / millisecondsInSecond

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -22,10 +22,11 @@ export async function nodesContainerFactory(runId: string) {
 
   let data: RunGraphData | null = null
   let layout: NodeLayoutResponse = new Map()
+  let interval: ReturnType<typeof setInterval> | undefined = undefined
 
   container.name = DEFAULT_NODES_CONTAINER_NAME
 
-  emitter.on('layoutUpdated', () => renderRun())
+  emitter.on('layoutUpdated', () => renderNodes())
 
   async function render(): Promise<void> {
     if (data === null) {
@@ -36,18 +37,20 @@ export async function nodesContainerFactory(runId: string) {
       throw new Error('Data was null after fetch')
     }
 
-    await renderRun()
-
-    if (!data.end_time) {
-      setTimeout(() => fetch(), DEFAULT_POLL_INTERVAL)
-    }
+    await renderNodes()
   }
 
   async function fetch(): Promise<void> {
+    clearInterval(interval)
+
     data = await config.fetch(runId)
+
+    if (!data.end_time) {
+      interval = setTimeout(() => fetch(), DEFAULT_POLL_INTERVAL)
+    }
   }
 
-  async function renderRun(): Promise<void> {
+  async function renderNodes(): Promise<void> {
     if (data === null) {
       return
     }

--- a/src/factories/position.ts
+++ b/src/factories/position.ts
@@ -7,14 +7,14 @@ export type HorizontalPositionSettings = {
   startTime: Date,
   timeSpan: number,
   timeSpanPixels: number,
-  dagColumnSize: number,
+  dependencyColumnSize: number,
 }
 
 export type HorizontalScale = ReturnType<typeof horizontalScaleFactory>
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function horizontalScaleFactory(settings: HorizontalPositionSettings) {
-  if (settings.mode === 'time') {
+  if (settings.mode === 'trace') {
     return getTimeScale(settings)
   }
 
@@ -36,6 +36,6 @@ function getTimeScale({ startTime, timeSpan, timeSpanPixels }: HorizontalPositio
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function getLinearScale({ dagColumnSize }: HorizontalPositionSettings) {
-  return scaleLinear().domain([0, 1]).range([0, dagColumnSize])
+function getLinearScale({ dependencyColumnSize }: HorizontalPositionSettings) {
+  return scaleLinear().domain([0, 1]).range([0, dependencyColumnSize])
 }

--- a/src/factories/settings.ts
+++ b/src/factories/settings.ts
@@ -8,6 +8,6 @@ export function horizontalSettingsFactory(startTime: Date): HorizontalPositionSe
     startTime,
     timeSpan: DEFAULT_TIME_COLUMN_SPAN_SECONDS,
     timeSpanPixels: DEFAULT_TIME_COLUMN_SIZE_PIXELS,
-    dagColumnSize: DEFAULT_LINEAR_COLUMN_SIZE_PIXELS,
+    dependencyColumnSize: DEFAULT_LINEAR_COLUMN_SIZE_PIXELS,
   }
 }

--- a/src/models/layout.ts
+++ b/src/models/layout.ts
@@ -1,17 +1,13 @@
-import { RunGraphNode } from '@/models/RunGraph'
-
 export type Pixels = { x: number, y: number }
 export type VerticalMode = 'waterfall' | 'nearest-parent'
-export type HorizontalMode = 'time' | 'dat'
+export type HorizontalMode = 'time' | 'dag'
+
 export type LayoutMode = {
   horizontal: HorizontalMode,
   vertical: VerticalMode,
 }
 
-export type NodeLayoutRequest = Map<string, {
-  node: RunGraphNode,
-  width: number,
-}>
+export type NodeWidths = Map<string, number>
 
 export type NodeLayoutResponse = Map<string, {
   x: number,

--- a/src/models/layout.ts
+++ b/src/models/layout.ts
@@ -1,6 +1,6 @@
 export type Pixels = { x: number, y: number }
 export type VerticalMode = 'waterfall' | 'nearest-parent'
-export type HorizontalMode = 'time' | 'dag'
+export type HorizontalMode = 'trace' | 'dependency'
 
 export type LayoutMode = {
   horizontal: HorizontalMode,

--- a/src/objects/layout.ts
+++ b/src/objects/layout.ts
@@ -1,12 +1,17 @@
+import { reactive } from 'vue'
 import { HorizontalMode, LayoutMode, VerticalMode } from '@/models/layout'
 import { emitter } from '@/objects/events'
 
-export const layout: LayoutMode = {
-  horizontal: 'time',
+export const layout: LayoutMode = reactive({
+  horizontal: 'trace',
   vertical: 'waterfall',
-}
+})
 
 export function setLayoutMode({ horizontal, vertical }: LayoutMode): void {
+  if (layout.horizontal === horizontal && layout.vertical === vertical) {
+    return
+  }
+
   layout.horizontal = horizontal
   layout.vertical = vertical
 
@@ -14,12 +19,20 @@ export function setLayoutMode({ horizontal, vertical }: LayoutMode): void {
 }
 
 export function setHorizontalMode(mode: HorizontalMode): void {
+  if (layout.horizontal === mode) {
+    return
+  }
+
   layout.horizontal = mode
 
   emitter.emit('layoutUpdated', layout)
 }
 
 export function setVerticalMode(mode: VerticalMode): void {
+  if (layout.vertical === mode) {
+    return
+  }
+
   layout.vertical = mode
 
   emitter.emit('layoutUpdated', layout)

--- a/src/workers/runGraph.ts
+++ b/src/workers/runGraph.ts
@@ -1,5 +1,6 @@
 import { HorizontalPositionSettings } from '@/factories/position'
-import { NodeLayoutRequest, NodeLayoutResponse } from '@/models/layout'
+import { NodeLayoutResponse, NodeWidths } from '@/models/layout'
+import { RunGraphData } from '@/models/RunGraph'
 
 // eslint-disable-next-line import/default
 import RunGraphWorker from '@/workers/runGraph.worker?worker'
@@ -9,7 +10,8 @@ export type WorkerMessage = WorkerLayoutMessage
 
 export type ClientLayoutMessage = {
   type: 'layout',
-  nodes: NodeLayoutRequest,
+  data: RunGraphData,
+  widths: NodeWidths,
   settings: HorizontalPositionSettings,
 }
 

--- a/src/workers/runGraph.worker.ts
+++ b/src/workers/runGraph.worker.ts
@@ -1,5 +1,6 @@
 import { horizontalScaleFactory } from '@/factories/position'
 import { NodeLayoutResponse } from '@/models/layout'
+import { RunGraphNodes } from '@/models/RunGraph'
 import { exhaustive } from '@/utilities/exhaustive'
 import { WorkerMessage, ClientMessage, ClientLayoutMessage } from '@/workers/runGraph'
 
@@ -21,14 +22,22 @@ function post(message: WorkerMessage): void {
   postMessage(message)
 }
 
-function handleLayoutMessage({ nodes, settings }: ClientLayoutMessage): void {
+function handleLayoutMessage(message: ClientLayoutMessage): void {
   let y = 0
-  const scale = horizontalScaleFactory(settings)
+  const { data } = message
+  const horizontal = getHorizontalLayout(message)
   const layout: NodeLayoutResponse = new Map()
 
-  nodes.forEach(({ node }, nodeId) => {
+  data.nodes.forEach((node, nodeId) => {
+    const x = horizontal.get(nodeId)
+
+    if (x === undefined) {
+      console.warn(`NodeId not found in horizontal layout: Skipping ${node.label}`)
+      return
+    }
+
     layout.set(nodeId, {
-      x: scale(node.start_time),
+      x,
       y: y++,
     })
   })
@@ -39,3 +48,67 @@ function handleLayoutMessage({ nodes, settings }: ClientLayoutMessage): void {
   })
 }
 
+type HorizontalLayout = Map<string, number>
+
+function getHorizontalLayout(message: ClientLayoutMessage): HorizontalLayout {
+  if (message.settings.mode === 'dag') {
+    return getHorizontalDagLayout(message)
+  }
+
+  return getHorizontalTimeLayout(message)
+}
+
+function getHorizontalDagLayout({ data, settings }: ClientLayoutMessage): HorizontalLayout {
+  const levels = getLevels(data.root_node_ids, data.nodes)
+  const scale = horizontalScaleFactory(settings)
+  const layout: HorizontalLayout = new Map()
+
+  data.nodes.forEach((node, nodeId) => {
+    layout.set(nodeId, scale(levels.get(nodeId)!))
+  })
+
+  return layout
+}
+
+function getHorizontalTimeLayout({ data, settings }: ClientLayoutMessage): HorizontalLayout {
+  const scale = horizontalScaleFactory(settings)
+  const layout: HorizontalLayout = new Map()
+
+  data.nodes.forEach((node, nodeId) => {
+    layout.set(nodeId, scale(node.start_time))
+  })
+
+  return layout
+}
+
+// Map<nodeId, level>
+type NodeLevels = Map<string, number>
+
+function getLevels(nodeIds: string[], nodes: RunGraphNodes, levels: NodeLevels = new Map()): NodeLevels {
+  nodeIds.forEach(nodeId => {
+    if (levels.has(nodeId)) {
+      return
+    }
+
+    const node = nodes.get(nodeId)
+
+    if (!node) {
+      throw new Error('Node id not found in nodes')
+    }
+
+    const parentLevels = node.parents.map(({ id }) => levels.get(id) ?? 0)
+
+    // -1 so that maxParentLevel + 1 is always at least 0
+    const maxParentLevel = Math.max(...parentLevels, -1)
+
+    levels.set(nodeId, maxParentLevel + 1)
+
+    const childNodeIds = node.children.map(({ id }) => id)
+
+    if (childNodeIds.length) {
+      getLevels(childNodeIds, nodes, levels)
+    }
+  })
+
+  return levels
+}

--- a/src/workers/runGraph.worker.ts
+++ b/src/workers/runGraph.worker.ts
@@ -51,14 +51,14 @@ function handleLayoutMessage(message: ClientLayoutMessage): void {
 type HorizontalLayout = Map<string, number>
 
 function getHorizontalLayout(message: ClientLayoutMessage): HorizontalLayout {
-  if (message.settings.mode === 'dag') {
-    return getHorizontalDagLayout(message)
+  if (message.settings.mode === 'dependency') {
+    return getHorizontalDependencyLayout(message)
   }
 
   return getHorizontalTimeLayout(message)
 }
 
-function getHorizontalDagLayout({ data, settings }: ClientLayoutMessage): HorizontalLayout {
+function getHorizontalDependencyLayout({ data, settings }: ClientLayoutMessage): HorizontalLayout {
   const levels = getLevels(data.root_node_ids, data.nodes)
   const scale = horizontalScaleFactory(settings)
   const layout: HorizontalLayout = new Map()


### PR DESCRIPTION
# Description
Adds the graph settings to the graph actions. This currently has two settings. Only view is supported at this point.
- View - How nodes are rendered along the x axis
    - Dependency - All nodes are the same size and ordered by how far from the "root" of the graph they are
    - Trace - Nodes are rendered according to run time
- Layout - How nodes are rendered along the y axis
    - Waterfall - Fastest layout which renders nodes along the y axis in order of when they occurred (first nodes at the top, last at the bottom)
    - Nearest Parent -  Slower layout which aims to render nodes more logically based on where a nodes parent nodes are located.
   
<img width="819" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/6685c8c3-bec6-4eb4-97ed-751516165805">
<img width="816" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/6a1bf4f0-9b98-4777-a9c2-388f7c63f399">

