### PR TITLE
Add the flow run toggle button

### DIFF
--- a/src/factories/arrow.ts
+++ b/src/factories/arrow.ts
@@ -2,7 +2,7 @@ import { useSubscription } from '@prefecthq/vue-compositions'
 import { Graphics, Rectangle, Sprite, Texture } from 'pixi.js'
 import { waitForApplication } from '@/objects'
 
-type ArrowStyle = {
+export type ArrowStyle = {
   size: number,
   radius?: number,
   stroke?: number,

--- a/src/factories/arrow.ts
+++ b/src/factories/arrow.ts
@@ -1,0 +1,58 @@
+import { useSubscription } from '@prefecthq/vue-compositions'
+import { Graphics, Rectangle, Sprite, Texture } from 'pixi.js'
+import { waitForApplication } from '@/objects'
+
+type ArrowStyle = {
+  size: number,
+  radius?: number,
+  stroke?: number,
+  rotate?: number,
+}
+
+export enum ArrowDirection {
+  Up = 0,
+  Down = 180,
+  Left = 270,
+  Right = 90
+}
+
+async function getArrowTexture({ size, stroke = 1, radius = 0 }: ArrowStyle): Promise<Texture> {
+  const application = await waitForApplication()
+
+  const graphic = new Graphics()
+  graphic.lineStyle(stroke, '#fff', 1, 0)
+  graphic.drawRoundedRect(0, 0, size * 2, size * 2, radius)
+
+  const arrow = application.renderer.generateTexture(graphic, {
+    // drew a rounded rectangle and then just using one corner as the "arrow"
+    region: new Rectangle(0, 0, size, size),
+
+    // manually bumping up the resolution to keep the border radius from being blurry
+    resolution: 10,
+  })
+
+  return arrow
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function arrowFactory() {
+  const arrow = new Sprite()
+
+  async function render(style: ArrowStyle): Promise<Sprite> {
+    const texture = (await useSubscription(getArrowTexture, [style]).promise()).response
+    arrow.texture = texture
+
+    const { rotate = 0 } = style
+
+    arrow.anchor.set(0.5, 0.5)
+    // texture is the corner of a rectangle so 45 deg defaults the arrow to pointing up
+    arrow.angle = 45 + rotate
+
+    return arrow
+  }
+
+  return {
+    arrow,
+    render,
+  }
+}

--- a/src/factories/bar.ts
+++ b/src/factories/bar.ts
@@ -2,13 +2,13 @@ import { ColorSource, Container } from 'pixi.js'
 import { capFactory } from '@/factories/cap'
 import { rectangleFactory } from '@/factories/rectangle'
 
-type BarStyle = {
+export type BarStyle = {
   width: number,
   height: number,
   background: ColorSource,
   radius: number,
-  capLeft?: false,
-  capRight?: false,
+  capLeft?: boolean,
+  capRight?: boolean,
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/src/factories/cap.ts
+++ b/src/factories/cap.ts
@@ -7,7 +7,7 @@ type CapStyle = {
   radius: number,
 }
 
-async function cap({ height, radius }: CapStyle): Promise<Texture> {
+async function getCapTexture({ height, radius }: CapStyle): Promise<Texture> {
   const application = await waitForApplication()
 
   const graphic = new Graphics()
@@ -37,7 +37,7 @@ export function capFactory() {
   const right = new Sprite()
 
   async function render(style: CapStyle): Promise<CapSprites> {
-    const texture = (await useSubscription(cap, [style]).promise()).response
+    const texture = (await useSubscription(getCapTexture, [style]).promise()).response
     left.texture = texture
     right.texture = texture
 

--- a/src/factories/nodeArrowButton.ts
+++ b/src/factories/nodeArrowButton.ts
@@ -1,0 +1,58 @@
+import { Container, ColorMatrixFilter } from 'pixi.js'
+import { ArrowDirection, ArrowStyle, arrowFactory } from '@/factories/arrow'
+import { BarStyle, barFactory } from '@/factories/bar'
+
+type NodeArrowBarStyles = {
+  arrow: Omit<ArrowStyle, 'rotate'>,
+  button: BarStyle,
+  isOpen: boolean,
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export async function nodeArrowButtonFactory() {
+  const container = new Container()
+  const { arrow, render: renderArrow } = await arrowFactory()
+  const { bar: button, render: renderBar } = await barFactory()
+  const filter = new ColorMatrixFilter()
+
+  container.eventMode = 'static'
+  container.cursor = 'pointer'
+  container.addChild(button)
+  container.addChild(arrow)
+
+  container.on('mouseover', onMouseover)
+  container.on('mouseout', onMouseout)
+
+  button.filters = [filter]
+
+  async function render({ arrow: arrowStyles, button: buttonStyles, isOpen }: NodeArrowBarStyles): Promise<Container> {
+    const rotate = isOpen ? ArrowDirection.Up : ArrowDirection.Down
+    const arrow = await renderArrow({ ...arrowStyles, rotate })
+    const bar = await renderBar(buttonStyles)
+
+    const middle = {
+      y: bar.height / 2,
+      x: bar.width / 2,
+    }
+
+    const offset = arrowStyles.size / 4
+
+    arrow.x = middle.x
+    arrow.y = isOpen ? middle.y + offset : middle.y - offset
+
+    return container
+  }
+
+  function onMouseover(): void {
+    filter.brightness(0.5, false)
+  }
+
+  function onMouseout(): void {
+    filter.brightness(1, false)
+  }
+
+  return {
+    container,
+    render,
+  }
+}

--- a/src/factories/nodeArrowButton.ts
+++ b/src/factories/nodeArrowButton.ts
@@ -12,18 +12,18 @@ type NodeArrowBarStyles = {
 export async function nodeArrowButtonFactory() {
   const container = new Container()
   const { arrow, render: renderArrow } = await arrowFactory()
-  const { bar: button, render: renderBar } = await barFactory()
+  const { bar, render: renderBar } = await barFactory()
   const filter = new ColorMatrixFilter()
 
   container.eventMode = 'static'
   container.cursor = 'pointer'
-  container.addChild(button)
+  container.addChild(bar)
   container.addChild(arrow)
 
   container.on('mouseover', onMouseover)
   container.on('mouseout', onMouseout)
 
-  button.filters = [filter]
+  bar.filters = [filter]
 
   async function render({ arrow: arrowStyles, button: buttonStyles, isOpen }: NodeArrowBarStyles): Promise<Container> {
     const rotate = isOpen ? ArrowDirection.Up : ArrowDirection.Down

--- a/src/factories/nodeFlowRun.ts
+++ b/src/factories/nodeFlowRun.ts
@@ -38,9 +38,13 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   async function render(node: RunGraphNode): Promise<Container> {
     const label = await renderLabel(node)
     const bar = await renderBar(node)
-    await renderArrow()
+    const arrow = await renderArrow()
 
-    label.position = await getLabelPosition(label, bar)
+    label.position = await getLabelPosition({
+      label,
+      bar,
+      arrow,
+    })
 
     return container
   }
@@ -53,7 +57,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     const middle = bar.height / 2
     const offset = size / 4
     arrow.y = isOpen ? middle - offset : middle + offset
-    arrow.x = 10
+    arrow.x = config.styles.nodeMargin + size
 
     return arrow
   }
@@ -90,17 +94,23 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     container.emit('resized')
   }
 
-  async function getLabelPosition(label: BitmapText, bar: Container): Promise<Pixels> {
+  type LabelPositionObjects = {
+    label: BitmapText,
+    bar: Container,
+    arrow: Sprite,
+  }
+
+  async function getLabelPosition({ label, arrow, bar }: LabelPositionObjects): Promise<Pixels> {
     const config = await waitForConfig()
 
     // todo: this should probably be nodePadding
     const margin = config.styles.nodeMargin
-    const inside = bar.width > margin + label.width + margin
+    const inside = bar.width > margin + label.width + arrow.width + margin
     const y = bar.height / 2 - label.height
 
     if (inside) {
       return {
-        x: margin,
+        x: margin + arrow.width + margin,
         y,
       }
     }

--- a/src/factories/nodeFlowRun.ts
+++ b/src/factories/nodeFlowRun.ts
@@ -1,10 +1,9 @@
-import { BitmapText, Container, Sprite } from 'pixi.js'
+import { ColorSource, Container } from 'pixi.js'
 import { DEFAULT_NODE_CONTAINER_NAME } from '@/consts'
-import { ArrowDirection, arrowFactory } from '@/factories/arrow'
 import { nodeLabelFactory } from '@/factories/label'
+import { nodeArrowButtonFactory } from '@/factories/nodeArrowButton'
 import { nodeBarFactory } from '@/factories/nodeBar'
 import { nodesContainerFactory } from '@/factories/nodes'
-import { Pixels } from '@/models/layout'
 import { RunGraphNode } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
 
@@ -15,51 +14,31 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   const container = new Container()
   const config = await waitForConfig()
   const { bar, render: renderBar } = await nodeBarFactory()
-  const { label, render: renderLabel } = await nodeLabelFactory()
+  const { label, render: renderLabelText } = await nodeLabelFactory()
   const { container: nodesContainer, render: renderNodes, stop: stopNodes } = await nodesContainerFactory(node.id)
-  const { arrow, render: renderArrowSprite } = await arrowFactory()
+  const { container: arrowButton, render: renderArrowButtonContainer } = await nodeArrowButtonFactory()
+
   let isOpen = false
 
   container.addChild(bar)
   container.addChild(label)
   container.addChild(nodesContainer)
-  container.addChild(arrow)
+  container.addChild(arrowButton)
 
   container.name = DEFAULT_NODE_CONTAINER_NAME
-  container.eventMode = 'static'
-  container.cursor = 'pointer'
 
-  container.on('click', toggle)
+  arrowButton.on('click', toggle)
 
   nodesContainer.visible = false
   nodesContainer.position = { x: 0, y: config.styles.nodeHeight }
   nodesContainer.on('resized', () => container.emit('resized'))
 
-  async function render(node: RunGraphNode): Promise<Container> {
-    const label = await renderLabel(node)
-    const bar = await renderBar(node)
-    const arrow = await renderArrow()
-
-    label.position = await getLabelPosition({
-      label,
-      bar,
-      arrow,
-    })
+  async function render(): Promise<Container> {
+    await renderBar(node)
+    await renderArrowButton()
+    await renderLabel()
 
     return container
-  }
-
-  async function renderArrow(): Promise<Sprite> {
-    const size = 10
-    const rotate = isOpen ? ArrowDirection.Down : ArrowDirection.Up
-    const arrow = await renderArrowSprite({ size, stroke: 2, radius: 2, rotate })
-
-    const middle = bar.height / 2
-    const offset = size / 4
-    arrow.y = isOpen ? middle - offset : middle + offset
-    arrow.x = config.styles.nodeMargin + size
-
-    return arrow
   }
 
   async function toggle(): Promise<void> {
@@ -75,7 +54,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     nodesContainer.visible = true
 
     await Promise.all([
-      render(node),
+      render(),
       renderNodes(),
     ])
 
@@ -87,38 +66,73 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     nodesContainer.visible = false
 
     await Promise.all([
-      render(node),
+      render(),
       stopNodes(),
     ])
 
     container.emit('resized')
   }
 
-  type LabelPositionObjects = {
-    label: BitmapText,
-    bar: Container,
-    arrow: Sprite,
+  async function renderArrowButton(): Promise<Container> {
+    const offset = 4
+    const buttonSize = config.styles.nodeHeight - offset
+    const inside = bar.width > buttonSize
+    const background = getArrowButtonBackground({ inside })
+
+    const container = await renderArrowButtonContainer({
+      arrow: {
+        size: 10,
+        stroke: 2,
+      },
+      button: {
+        width: buttonSize,
+        height: buttonSize,
+        background: background,
+        radius: config.styles.nodeBorderRadius - offset / 2,
+      },
+      isOpen,
+    })
+
+    container.x = inside ? offset / 2 : bar.width + config.styles.nodeMargin
+    container.y = offset / 2
+
+    return container
   }
 
-  async function getLabelPosition({ label, arrow, bar }: LabelPositionObjects): Promise<Pixels> {
-    const config = await waitForConfig()
+  type ArrowButtonBackgroundParameters = {
+    inside: boolean,
+  }
+
+  function getArrowButtonBackground({ inside }: ArrowButtonBackgroundParameters): ColorSource {
+    if (inside) {
+      const { background } = config.styles.node(node)
+
+      return background ?? '#fff'
+    }
+
+    return '#333'
+  }
+
+
+  async function renderLabel(): Promise<Container> {
+    const label = await renderLabelText(node)
 
     // todo: this should probably be nodePadding
     const margin = config.styles.nodeMargin
-    const inside = bar.width > margin + label.width + arrow.width + margin
-    const y = bar.height / 2 - label.height
 
-    if (inside) {
-      return {
-        x: margin + arrow.width + margin,
-        y,
-      }
-    }
+    const barRight = bar.x + bar.width
+    const buttonRight = arrowButton.x + arrowButton.width
+    const barWithoutMargin = bar.width - margin * 2
 
-    return {
-      x: bar.width + margin,
-      y,
-    }
+    const labelMinLeft = Math.max(barRight, buttonRight)
+    const inside = barWithoutMargin > labelMinLeft + label.width
+    const y = bar.height / 2
+    const x = inside ? labelMinLeft + margin : arrowButton.x + arrowButton.width + margin
+
+    label.anchor.set(0, 0.5)
+    label.position = { x, y }
+
+    return label
   }
 
   return {

--- a/src/factories/rectangle.ts
+++ b/src/factories/rectangle.ts
@@ -2,7 +2,7 @@ import { useSubscription } from '@prefecthq/vue-compositions'
 import { Graphics, RenderTexture, Sprite } from 'pixi.js'
 import { waitForApplication } from '@/objects'
 
-async function rectangle(): Promise<RenderTexture> {
+async function getRectangleTexture(): Promise<RenderTexture> {
   const application = await waitForApplication()
 
   const rectangle = new Graphics()
@@ -16,7 +16,7 @@ async function rectangle(): Promise<RenderTexture> {
 }
 
 export async function rectangleFactory(): Promise<Sprite> {
-  const texture = (await useSubscription(rectangle).promise()).response
+  const texture = (await useSubscription(getRectangleTexture).promise()).response
 
   return new Sprite(texture)
 }

--- a/src/objects/config.ts
+++ b/src/objects/config.ts
@@ -10,7 +10,7 @@ const defaults: Omit<RequiredGraphConfig, 'runId' | 'fetch'> = {
   animationDuration: 500,
   styles: {
     nodeHeight: 30,
-    nodeMargin: 2,
+    nodeMargin: 4,
     nodeBorderRadius: 8,
     node: () => ({
       background: '#ffffff',


### PR DESCRIPTION
# Description
Adds the arrow toggle button to flow run nodes. If it can its fit inside the nodes bar. Otherwise its is positioned to the right of the bar. Same as it is today. 

It has a slightly different style than it does today. We can tweak/change this. Specifically adding a border to it when hovering. I just didn't want to make this PR to large. 

Normal
<img width="506" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/a0a8a0bb-e09e-4954-87e9-3150a1c08e8a">
Hovering inside - Different than what we have today. Not because I think this is necessarily better but it is much simpler. We can update this later if we want to. 
<img width="485" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/2ac9b3d5-5931-4a52-aed1-1a9d08a612b0">
Hovering outside - This is where we really need that border (coming soon)
<img width="482" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/d51be9a7-fbc3-43cb-8fee-ca47fca31ca8">

