### PR TITLE
Fix cap textures being recreated for every node

### DIFF
--- a/src/factories/bar.ts
+++ b/src/factories/bar.ts
@@ -24,7 +24,10 @@ export async function barFactory() {
   async function render(style: BarStyle): Promise<Container> {
     const { width, x, visible } = getRectangleStyles(style)
 
-    await renderCaps(style)
+    await renderCaps({
+      height: style.height,
+      radius: style.radius,
+    })
 
     rectangle.visible = visible
     rectangle.width = width


### PR DESCRIPTION
# Description
Since I was passing the entire `style` object into the subscription it was including the width of each bar as part of the subscription arguments. This meant there were no cache hits. Only passing in the exact parameters means we get a cache hit every time on the subscription. 