### PR TITLE
Row and column gaps

### DIFF
--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -4,7 +4,7 @@ import { EdgeFactory, edgeFactory } from '@/factories/edge'
 import { NodeContainerFactory, nodeContainerFactory } from '@/factories/node'
 import { offsetsFactory } from '@/factories/offsets'
 import { horizontalSettingsFactory, verticalSettingsFactory } from '@/factories/settings'
-import { NodesLayoutResponse, NodeSize, NodeWidths, Pixels } from '@/models/layout'
+import { NodesLayoutResponse, NodeSize, NodeWidths, Pixels, NodeLayoutResponse } from '@/models/layout'
 import { RunGraphData, RunGraphNode } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
@@ -217,24 +217,22 @@ export async function nodesContainerFactory(runId: string) {
     setPositions()
   }
 
-  function getActualPosition(position: Pixels): Pixels {
+  function getActualPosition(position: NodeLayoutResponse): Pixels {
     const y = rows.getTotalOffset(position.y)
-    const { x } = position
-
-    if (layout.horizontal === 'dependency') {
-      const column = position.x / DEFAULT_LINEAR_COLUMN_SIZE_PIXELS
-      const x = position.x + column * config.styles.columnGap
-
-      return {
-        y,
-        x,
-      }
-    }
+    const x = getActualXPosition(position)
 
     return {
       x,
       y,
     }
+  }
+
+  function getActualXPosition(position: NodeLayoutResponse): number {
+    if (layout.horizontal === 'dependency') {
+      return position.x + position.column * config.styles.columnGap
+    }
+
+    return position.x
   }
 
   function resized(): void {

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -138,12 +138,12 @@ export async function nodesContainerFactory(runId: string) {
 
       if (!parentPosition || !childPosition) {
         console.warn(`Could not find edge in layout: Skipping ${edgeId}`)
-        return
+        continue
       }
 
       if (!parentNode) {
         console.warn(`Could not find parent node in nodes: Skipping ${parentId}`)
-        return
+        continue
       }
 
       const parentBarWidth = parentNode.bar.width
@@ -169,7 +169,8 @@ export async function nodesContainerFactory(runId: string) {
 
       if (!position) {
         console.warn(`Could not find node in layout: Skipping ${nodeId}`)
-        return
+        node.container.visible = false
+        continue
       }
 
       const newPosition = getActualPosition(position)
@@ -220,6 +221,16 @@ export async function nodesContainerFactory(runId: string) {
   function getActualPosition(position: Pixels): Pixels {
     const y = rows.getTotalOffset(position.y)
     const { x } = position
+
+    if (layout.horizontal === 'dependency') {
+      const column = position.x / DEFAULT_LINEAR_COLUMN_SIZE_PIXELS
+      const x = position.x + column * config.styles.columnGap
+
+      return {
+        y,
+        x,
+      }
+    }
 
     return {
       x,

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -23,7 +23,10 @@ export async function nodesContainerFactory(runId: string) {
   const edges = new Map<EdgeKey, EdgeFactory>()
   const container = new Container()
   const config = await waitForConfig()
-  const rows = await offsetsFactory()
+  const rows = await offsetsFactory({
+    gap: config.styles.rowGap,
+    minimum: config.styles.nodeHeight,
+  })
   let initialized = false
 
   let data: RunGraphData | null = null

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -169,7 +169,6 @@ export async function nodesContainerFactory(runId: string) {
 
       if (!position) {
         console.warn(`Could not find node in layout: Skipping ${nodeId}`)
-        node.container.visible = false
         continue
       }
 

--- a/src/factories/offsets.ts
+++ b/src/factories/offsets.ts
@@ -1,5 +1,3 @@
-import { waitForConfig } from '@/objects/config'
-
 type SetOffsetParameters = {
   axis: number,
   nodeId: string,
@@ -13,15 +11,21 @@ type RemoveOffsetParameters = {
 
 export type Offsets = Awaited<ReturnType<typeof offsetsFactory>>
 
+export type OffsetParameters = {
+  gap?: number,
+  minimum?: number,
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export async function offsetsFactory() {
-  const config = await waitForConfig()
+export function offsetsFactory({ gap = 0, minimum = 0 }: OffsetParameters = {}) {
   const offsets: Map<number, Map<string, number> | undefined> = new Map()
 
   function getOffset(axis: number): number {
     const values = offsets.get(axis) ?? []
+    const value = Math.max(...values.values(), minimum)
+    const valueWithGap = value + gap
 
-    return Math.max(...values.values(), config.styles.nodeHeight)
+    return valueWithGap
   }
 
   function getTotalOffset(axis: number): number {

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -47,6 +47,8 @@ export type RunGraphNodeStyles = {
 }
 
 export type RunGraphStyles = {
+  rowGap?: number,
+  columnGap?: number,
   nodeHeight?: number,
   nodeMargin?: number,
   nodeBorderRadius?: number,

--- a/src/models/layout.ts
+++ b/src/models/layout.ts
@@ -20,4 +20,8 @@ export type NodeLayoutResponse = {
   row: number,
 }
 
-export type NodesLayoutResponse = Map<string, NodeLayoutResponse>
+export type NodesLayoutResponse = {
+  maxRow: number,
+  maxColumn: number,
+  positions: Map<string, NodeLayoutResponse>,
+}

--- a/src/models/layout.ts
+++ b/src/models/layout.ts
@@ -16,6 +16,8 @@ export type NodeWidths = Map<string, number>
 export type NodeLayoutResponse = {
   x: number,
   y: number,
+  column: number,
+  row: number,
 }
 
 export type NodesLayoutResponse = Map<string, NodeLayoutResponse>

--- a/src/objects/config.ts
+++ b/src/objects/config.ts
@@ -9,6 +9,8 @@ let config: RequiredGraphConfig | null = null
 const defaults: Omit<RequiredGraphConfig, 'runId' | 'fetch'> = {
   animationDuration: 500,
   styles: {
+    rowGap: 20,
+    columnGap: 40,
     nodeHeight: 30,
     nodeMargin: 4,
     nodeBorderRadius: 8,

--- a/src/objects/config.ts
+++ b/src/objects/config.ts
@@ -9,8 +9,8 @@ let config: RequiredGraphConfig | null = null
 const defaults: Omit<RequiredGraphConfig, 'runId' | 'fetch'> = {
   animationDuration: 500,
   styles: {
-    rowGap: 20,
-    columnGap: 40,
+    rowGap: 15,
+    columnGap: 30,
     nodeHeight: 30,
     nodeMargin: 4,
     nodeBorderRadius: 8,

--- a/src/objects/layout.ts
+++ b/src/objects/layout.ts
@@ -3,7 +3,7 @@ import { HorizontalMode, LayoutMode, VerticalMode } from '@/models/layout'
 import { emitter } from '@/objects/events'
 
 export const layout: LayoutMode = reactive({
-  horizontal: 'dependency',
+  horizontal: 'trace',
   vertical: 'nearest-parent',
 })
 

--- a/src/objects/layout.ts
+++ b/src/objects/layout.ts
@@ -3,8 +3,8 @@ import { HorizontalMode, LayoutMode, VerticalMode } from '@/models/layout'
 import { emitter } from '@/objects/events'
 
 export const layout: LayoutMode = reactive({
-  horizontal: 'trace',
-  vertical: 'waterfall',
+  horizontal: 'dependency',
+  vertical: 'nearest-parent',
 })
 
 export function setLayoutMode({ horizontal, vertical }: LayoutMode): void {

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -65,7 +65,9 @@ export async function centerViewport({ animate }: CenterViewportParameters = {})
 
   uncull()
   const { x, y, width, height } = container.getLocalBounds()
-  const scale = viewport.findFit(width, height)
+  const widthWithGap = width + config.styles.columnGap
+  const heightWithGap = height + config.styles.rowGap
+  const scale = viewport.findFit(widthWithGap, heightWithGap)
 
   // if the container doesn't have a size we cannot do anything here
   if (!width || !height) {

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -65,8 +65,8 @@ export async function centerViewport({ animate }: CenterViewportParameters = {})
 
   uncull()
   const { x, y, width, height } = container.getLocalBounds()
-  const widthWithGap = width + config.styles.columnGap
-  const heightWithGap = height + config.styles.rowGap
+  const widthWithGap = width + config.styles.columnGap * 2
+  const heightWithGap = height + config.styles.rowGap * 2
   const scale = viewport.findFit(widthWithGap, heightWithGap)
 
   // if the container doesn't have a size we cannot do anything here

--- a/src/workers/layouts/nearestParentVertical.ts
+++ b/src/workers/layouts/nearestParentVertical.ts
@@ -32,7 +32,7 @@ export async function getVerticalNearestParentLayout(message: ClientLayoutMessag
   return layout
 
   async function getNearestParentPosition(node: RunGraphNode): Promise<number> {
-    const nodeStartX = horizontal.get(node.id)
+    const { x: nodeStartX } = horizontal.get(node.id) ?? {}
 
     if (nodeStartX === undefined) {
       console.warn('NearestParentLayout: Node was not found in the horizontal layout', node.id)
@@ -198,7 +198,7 @@ export async function getVerticalNearestParentLayout(message: ClientLayoutMessag
     for await (const nodeId of overlappingNodeIds) {
       // push nodes and recursively shove as needed
       const overlappingRow = layout.get(nodeId)
-      const nodeStartX = horizontal.get(nodeId)
+      const { x: nodeStartX } = horizontal.get(nodeId) ?? {}
 
       if (overlappingRow === undefined || nodeStartX === undefined) {
         console.warn('NearestParentLayout - shove: Node was not found in the vertical or horizontal layout', nodeId)
@@ -415,7 +415,7 @@ export async function getVerticalNearestParentLayout(message: ClientLayoutMessag
   }
 
   function getNodeEndX(nodeId: string): number {
-    const nodeStartX = horizontal.get(nodeId)
+    const { x: nodeStartX } = horizontal.get(nodeId) ?? {}
     const nodeWidth = message.widths.get(nodeId)
 
     if (nodeStartX === undefined || nodeWidth === undefined) {

--- a/src/workers/layouts/vertical.ts
+++ b/src/workers/layouts/vertical.ts
@@ -1,6 +1,6 @@
 import { HorizontalLayout } from '@/workers/layouts/horizontal'
+import { getVerticalNearestParentLayout } from '@/workers/layouts/nearestParentVertical'
 import { ClientLayoutMessage } from '@/workers/runGraph'
-import { getVerticalNearestParentLayout } from './nearestParentVertical'
 
 export type VerticalLayout = Map<string, number>
 

--- a/src/workers/runGraph.worker.ts
+++ b/src/workers/runGraph.worker.ts
@@ -32,12 +32,12 @@ async function handleLayoutMessage(message: ClientLayoutMessage): Promise<void> 
     const horizontal = horizontalLayout.get(nodeId)
     const vertical = verticalLayout.get(nodeId)
 
-    if (!horizontal) {
+    if (horizontal === undefined) {
       console.warn(`NodeId not found in horizontal layout: Skipping ${node.label}`)
       continue
     }
 
-    if (!vertical) {
+    if (vertical === undefined) {
       console.warn(`NodeId not found in vertical layout: Skipping ${node.label}`)
       continue
     }

--- a/src/workers/runGraph.worker.ts
+++ b/src/workers/runGraph.worker.ts
@@ -26,7 +26,10 @@ async function handleLayoutMessage(message: ClientLayoutMessage): Promise<void> 
   const { data } = message
   const horizontalLayout = getHorizontalLayout(message)
   const verticalLayout = await getVerticalLayout(message, horizontalLayout)
-  const layout: NodesLayoutResponse = new Map()
+  const positions: NodesLayoutResponse['positions'] = new Map()
+
+  let maxRow = 0
+  let maxColumn = 0
 
   for (const [nodeId, node] of data.nodes) {
     const horizontal = horizontalLayout.get(nodeId)
@@ -42,7 +45,10 @@ async function handleLayoutMessage(message: ClientLayoutMessage): Promise<void> 
       continue
     }
 
-    layout.set(nodeId, {
+    maxRow = Math.max(maxRow, vertical)
+    maxColumn = Math.max(maxColumn, horizontal.column)
+
+    positions.set(nodeId, {
       ...horizontal,
       y: vertical,
       row: vertical,
@@ -51,6 +57,10 @@ async function handleLayoutMessage(message: ClientLayoutMessage): Promise<void> 
 
   post({
     type: 'layout',
-    layout,
+    layout: {
+      maxRow,
+      maxColumn,
+      positions,
+    },
   })
 }

--- a/src/workers/runGraph.worker.ts
+++ b/src/workers/runGraph.worker.ts
@@ -24,27 +24,28 @@ function post(message: WorkerMessage): void {
 
 async function handleLayoutMessage(message: ClientLayoutMessage): Promise<void> {
   const { data } = message
-  const horizontal = getHorizontalLayout(message)
-  const vertical = await getVerticalLayout(message, horizontal)
+  const horizontalLayout = getHorizontalLayout(message)
+  const verticalLayout = await getVerticalLayout(message, horizontalLayout)
   const layout: NodesLayoutResponse = new Map()
 
   for (const [nodeId, node] of data.nodes) {
-    const x = horizontal.get(nodeId)
-    const y = vertical.get(nodeId)
+    const horizontal = horizontalLayout.get(nodeId)
+    const vertical = verticalLayout.get(nodeId)
 
-    if (x === undefined) {
+    if (!horizontal) {
       console.warn(`NodeId not found in horizontal layout: Skipping ${node.label}`)
-      return
+      continue
     }
 
-    if (y === undefined) {
+    if (!vertical) {
       console.warn(`NodeId not found in vertical layout: Skipping ${node.label}`)
-      return
+      continue
     }
 
     layout.set(nodeId, {
-      x,
-      y,
+      ...horizontal,
+      y: vertical,
+      row: vertical,
     })
   }
 


### PR DESCRIPTION
# Description
Adds some configurable gap between rows and columns. This is most noticeable when looking at the dependency view. Also moves some row/column logic to the worker so the layout response is more useful. 

Before
<img width="1322" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/c517c0d2-f182-40c9-81c2-bee4b39d85e1">

After
<img width="1333" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6200442/f952e13a-f096-45d0-8b2c-799c83c2aa3c">
