### PR TITLE
Factor in width of sub nodes to expanded nodes

### DIFF
--- a/src/factories/nodeBar.ts
+++ b/src/factories/nodeBar.ts
@@ -29,7 +29,7 @@ export async function nodeBarFactory() {
   }
 
   function getTotalWidth(node: RunGraphNode, borderRadius: number): number {
-    if (layout.horizontal === 'trace') {
+    if (layout.isTrace()) {
       const right = node.start_time
       const left = node.end_time ?? new Date()
       const seconds = differenceInMilliseconds(left, right) / millisecondsInSecond

--- a/src/factories/nodeFlowRun.ts
+++ b/src/factories/nodeFlowRun.ts
@@ -88,6 +88,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     ])
 
     nodesContainer.visible = true
+    // todo: can we just set the viewport to dirty here?
     nodesContainer.once('rendered', () => cull())
 
     resized()

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -304,9 +304,7 @@ export async function nodesContainerFactory(runId: string) {
   }
 
   function handleLayoutMessage(data: WorkerLayoutMessage): void {
-    // eslint-disable-next-line prefer-destructuring
     nodesLayout = data.layout
-
     setPositions()
   }
 

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -240,7 +240,7 @@ export async function nodesContainerFactory(runId: string) {
   }
 
   function getActualXPosition(position: NodeLayoutResponse): number {
-    if (layout.horizontal === 'dependency') {
+    if (layout.isDependency()) {
       return position.x + position.column * config.styles.columnGap
     }
 

--- a/src/factories/offsets.ts
+++ b/src/factories/offsets.ts
@@ -1,3 +1,5 @@
+import { toValue } from 'vue'
+
 type SetOffsetParameters = {
   axis: number,
   nodeId: string,
@@ -9,11 +11,13 @@ type RemoveOffsetParameters = {
   nodeId: string,
 }
 
+type MaybeGetter<T> = T | (() => T)
+
 export type Offsets = Awaited<ReturnType<typeof offsetsFactory>>
 
 export type OffsetParameters = {
-  gap?: number,
-  minimum?: number,
+  gap?: MaybeGetter<number>,
+  minimum?: MaybeGetter<number>,
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -22,8 +26,8 @@ export function offsetsFactory({ gap = 0, minimum = 0 }: OffsetParameters = {}) 
 
   function getOffset(axis: number): number {
     const values = offsets.get(axis) ?? []
-    const value = Math.max(...values.values(), minimum)
-    const valueWithGap = value + gap
+    const value = Math.max(...values.values(), toValue(minimum))
+    const valueWithGap = value + toValue(gap)
 
     return valueWithGap
   }
@@ -39,7 +43,7 @@ export function offsetsFactory({ gap = 0, minimum = 0 }: OffsetParameters = {}) 
   }
 
   function getTotalValue(axis: number): number {
-    return getTotalOffset(axis + 1)
+    return getTotalOffset(axis + 1) - toValue(gap)
   }
 
   function setOffset({ axis, nodeId, offset }: SetOffsetParameters): void {

--- a/src/models/layout.ts
+++ b/src/models/layout.ts
@@ -9,6 +9,10 @@ export type NodeSize = {
 export type LayoutMode = {
   horizontal: HorizontalMode,
   vertical: VerticalMode,
+  isTrace: () => boolean,
+  isDependency: () => boolean,
+  isWaterfall: () => boolean,
+  isNearestParent: () => boolean,
 }
 
 export type NodeWidths = Map<string, number>

--- a/src/models/layout.ts
+++ b/src/models/layout.ts
@@ -4,6 +4,7 @@ export type HorizontalMode = 'trace' | 'dependency'
 
 export type NodeSize = {
   height: number,
+  width: number,
 }
 
 export type LayoutMode = {

--- a/src/objects/layout.ts
+++ b/src/objects/layout.ts
@@ -2,9 +2,21 @@ import { reactive } from 'vue'
 import { HorizontalMode, LayoutMode, VerticalMode } from '@/models/layout'
 import { emitter } from '@/objects/events'
 
-export const layout: LayoutMode = reactive({
+export const layout = reactive<LayoutMode>({
   horizontal: 'trace',
   vertical: 'nearest-parent',
+  isTrace() {
+    return this.horizontal === 'trace'
+  },
+  isDependency() {
+    return this.horizontal === 'dependency'
+  },
+  isWaterfall() {
+    return this.vertical === 'waterfall'
+  },
+  isNearestParent() {
+    return this.vertical === 'nearest-parent'
+  },
 })
 
 export function setLayoutMode({ horizontal, vertical }: LayoutMode): void {

--- a/src/pixi.d.ts
+++ b/src/pixi.d.ts
@@ -1,6 +1,6 @@
 declare namespace GlobalMixins {
   interface DisplayObjectEvents {
-    resized: [{ height: number }],
+    resized: [{ height: number, width: number }],
     rendered: [],
   }
 }


### PR DESCRIPTION
# Description
Up until this we've only tracked offsets for the y axis. Which works great for the trace layout. Because with a trace the sub nodes are always the same width (or smaller) than the parent node. 

But with dependency node that is almost always not the case. A parent node will be a single column and the sub nodes will almost always be multiple columns. So we must track width to offset columns as well as rows. 

Before
![image](https://github.com/PrefectHQ/graphs/assets/6200442/dac57f1a-e7de-47d1-bf2d-72789b7ad521)

After
![image](https://github.com/PrefectHQ/graphs/assets/6200442/18589ff8-049b-49e6-8172-de3773b6541d)
