### PR TITLE
Fix incorrect layout when objects are culled

### DIFF
--- a/src/factories/node.ts
+++ b/src/factories/node.ts
@@ -1,7 +1,8 @@
-import { Container, Ticker } from 'pixi.js'
+import { Ticker } from 'pixi.js'
 import { animate } from '@/factories/animation'
 import { FlowRunContainer, flowRunContainerFactory } from '@/factories/nodeFlowRun'
 import { TaskRunContainer, taskRunContainerFactory } from '@/factories/nodeTaskRun'
+import { BoundsContainer } from '@/models/boundsContainer'
 import { Pixels } from '@/models/layout'
 import { RunGraphNode } from '@/models/RunGraph'
 import { waitForCull } from '@/objects/culling'
@@ -16,7 +17,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
 
   cull.add(container)
 
-  async function render(node: RunGraphNode): Promise<Container> {
+  async function render(node: RunGraphNode): Promise<BoundsContainer> {
     const currentCacheKey = getNodeCacheKey(node)
 
     if (currentCacheKey === cacheKey) {

--- a/src/factories/nodeTaskRun.ts
+++ b/src/factories/nodeTaskRun.ts
@@ -1,7 +1,8 @@
-import { BitmapText, Container } from 'pixi.js'
+import { BitmapText } from 'pixi.js'
 import { DEFAULT_NODE_CONTAINER_NAME } from '@/consts'
 import { nodeLabelFactory } from '@/factories/label'
 import { nodeBarFactory } from '@/factories/nodeBar'
+import { BoundsContainer } from '@/models/boundsContainer'
 import { Pixels } from '@/models/layout'
 import { RunGraphNode } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
@@ -10,7 +11,7 @@ export type TaskRunContainer = Awaited<ReturnType<typeof taskRunContainerFactory
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function taskRunContainerFactory() {
-  const container = new Container()
+  const container = new BoundsContainer()
   const { element: label, render: renderLabel } = await nodeLabelFactory()
   const { element: bar, render: renderBar } = await nodeBarFactory()
 
@@ -20,7 +21,7 @@ export async function taskRunContainerFactory() {
   container.eventMode = 'none'
   container.name = DEFAULT_NODE_CONTAINER_NAME
 
-  async function render(node: RunGraphNode): Promise<Container> {
+  async function render(node: RunGraphNode): Promise<BoundsContainer> {
     const label = await renderLabel(node)
     const bar = await renderBar(node)
 
@@ -29,7 +30,7 @@ export async function taskRunContainerFactory() {
     return container
   }
 
-  async function getLabelPosition(label: BitmapText, bar: Container): Promise<Pixels> {
+  async function getLabelPosition(label: BitmapText, bar: BoundsContainer): Promise<Pixels> {
     const config = await waitForConfig()
 
     // todo: this should probably be nodePadding

--- a/src/models/boundsContainer.ts
+++ b/src/models/boundsContainer.ts
@@ -1,0 +1,81 @@
+// Not fixing linting errors from pixi source code
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+
+import { Container, MaskData } from 'pixi.js'
+
+/**
+ * This container extends the container from pixi but overrides
+ * the updateTransform and calculateBounds methods.
+ * The versions of these methods here are functional copies
+ * except these version also check children whose renderable
+ * or visible property is set to false. This means a BoundsContainer
+ * will have the same bounds even if some or all of its children are not
+ * rendered. This is important for any container where we need to know the actual
+ * size of the container even if its children have been culled.
+ */
+export class BoundsContainer extends Container {
+  public updateTransform(): void {
+    if (this.sortableChildren && this.sortDirty) {
+      this.sortChildren()
+    }
+
+    this._boundsID++
+
+    this.transform.updateTransform(this.parent.transform)
+
+    // TODO: check render flags, how to process stuff here
+    this.worldAlpha = this.alpha * this.parent.worldAlpha
+
+    for (let i = 0, j = this.children.length; i < j; ++i) {
+      const child = this.children[i]
+
+      /**
+       * This if statement has been commented out so children always
+       * have their transform updated for bounds calculation
+       */
+      // if (child.visible) {
+      child.updateTransform()
+      // }
+    }
+  }
+
+
+  public calculateBounds(): void {
+    this._bounds.clear()
+
+    this._calculateBounds()
+
+    for (const child of this.children) {
+
+      /**
+       * This if statement from the original version has been commented out
+       * we always want all children of this type of container to be included
+       * in the bounds of this container
+       */
+      // if (!child.visible || !child.renderable) {
+      //   continue
+      // }
+
+      child.calculateBounds()
+
+      if (child._mask) {
+        const maskObject = ((child._mask as MaskData).isMaskData
+          ? (child._mask as MaskData).maskObject : child._mask) as Container
+
+        if (maskObject) {
+          maskObject.calculateBounds()
+          this._bounds.addBoundsMask(child._bounds, maskObject._bounds)
+        } else {
+          this._bounds.addBounds(child._bounds)
+        }
+      } else if (child.filterArea) {
+        this._bounds.addBoundsArea(child._bounds, child.filterArea)
+      } else {
+        this._bounds.addBounds(child._bounds)
+      }
+    }
+
+    this._bounds.updateID = this._boundsID
+  }
+
+}


### PR DESCRIPTION
# Description
Because various parts of the layout depend on the physical size of objects its important those objects bounds are calculated correctly. When pixi calculates the bounds of a container it skips any children that have their `visible` or `renderable` properties set to false. Which means if a node or label is culled and a layout calculation is requested, the layout will be calculated using the wrong dimensions. 

To fix this I'm extending pixi's built in `Container` class with a custom `BoundsContainer` and using this new custom class for node containers. This custom implementation is exactly the same as the pixi version EXCEPT it does not skip any children even if their `visible` or `renderable` properties are set to false. This means that the bounds is always accurate. 

Pixi still skips these children when rendering. So we still get the majority (if not all) of the performance boost of culling. From my testing the performance impact of this change was unnoticeable with 2k nodes. And it fixed the layout problem

## Reproduction
1. Use the dependency view
2. Zoom out until labels dissapear
3. Switch to trace view
4. Recenter the viewport

Before
![image](https://github.com/PrefectHQ/graphs/assets/6200442/e53b2fb3-10ca-4003-b762-1cea8a8abd67)

After
![image](https://github.com/PrefectHQ/graphs/assets/6200442/495e0e8f-633d-4fa7-9cc9-1debc44ccfb5)
