### PR TITLE
Refactor how run data is fetched and rendered

### DIFF
--- a/src/factories/data.ts
+++ b/src/factories/data.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_POLL_INTERVAL } from '@/consts'
+import { RunGraphData } from '@/models/RunGraph'
+import { waitForConfig } from '@/objects/config'
+
+type DataCallback = (data: RunGraphData) => void
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export async function dataFactory(runId: string, callback: DataCallback) {
+  const config = await waitForConfig()
+
+  let interval: ReturnType<typeof setInterval> | undefined = undefined
+
+  async function start(): Promise<void> {
+    const data = await config.fetch(runId)
+
+    callback(data)
+
+    if (!data.end_time) {
+      interval = setTimeout(() => start(), DEFAULT_POLL_INTERVAL)
+    }
+  }
+
+  // todo: need a global way of stopping this when the graph is stopped
+  function stop(): void {
+    clearInterval(interval)
+  }
+
+  return {
+    start,
+    stop,
+  }
+
+}

--- a/src/objects/events.ts
+++ b/src/objects/events.ts
@@ -25,6 +25,7 @@ type Events = {
   fontsLoaded: Fonts,
   containerCreated: Container,
   layoutUpdated: LayoutSettings,
+  layoutCreated: LayoutSettings,
   cullCreated: Cull,
   labelCullCreated: VisibilityCull,
   edgeCullCreated: VisibilityCull,

--- a/src/objects/index.ts
+++ b/src/objects/index.ts
@@ -9,6 +9,7 @@ import { startLabelCulling, stopLabelCulling } from '@/objects/labelCulling'
 import { startNodes, stopNodes } from '@/objects/nodes'
 import { startScale, stopScale } from '@/objects/scale'
 import { startScope, stopScope } from '@/objects/scope'
+import { startSettings, stopSettings } from '@/objects/settings'
 import { startStage, stopStage } from '@/objects/stage'
 import { startViewport, stopViewport } from '@/objects/viewport'
 
@@ -33,6 +34,7 @@ export function start({ stage, props }: StartParameters): void {
   startCulling()
   startLabelCulling()
   startEdgeCulling()
+  startSettings()
 }
 
 export function stop(): void {
@@ -49,4 +51,5 @@ export function stop(): void {
   stopCulling()
   stopLabelCulling()
   stopEdgeCulling()
+  stopSettings()
 }


### PR DESCRIPTION
# Description
Previously the nodesContainerFactory was responsible for fetching and rendering its data. This was different than the rest of the factories but worked well up until now. But in order to set the initial horizontal scale we need to know how long the run was. So pulling out the fetching of data from the rendering of data. 