### PR TITLE
Better culling with animations

### DIFF
--- a/src/factories/animation.ts
+++ b/src/factories/animation.ts
@@ -1,22 +1,17 @@
 import gsap from 'gsap'
-import { waitForViewport } from '@/objects'
 import { waitForConfig } from '@/objects/config'
+import { cull } from '@/objects/culling'
 
 export async function animate(el: gsap.TweenTarget, vars: gsap.TweenVars, skipAnimation?: boolean): Promise<gsap.core.Tween> {
   const config = await waitForConfig()
-  const viewport = await waitForViewport()
   const duration = skipAnimation ? 0 : config.animationDuration / 1000
 
   return gsap.to(el, {
     ...vars,
     duration,
     ease: 'power1.out',
-  }).then(() => {
-    if (!skipAnimation) {
-      // setting the viewport dirty here will allow culling to take place after any
-      // number of animations that may have been called at once have completed, rather
-      // than calling cull() n number of times all at once.
-      viewport.dirty = true
-    }
+    onUpdate: () => {
+      cull()
+    },
   })
 }

--- a/src/objects/culling.ts
+++ b/src/objects/culling.ts
@@ -39,13 +39,9 @@ export function stopCulling(): void {
 }
 
 export async function cull(): Promise<void> {
-  if (!cullInstance) {
-    return
-  }
+  const viewport = await waitForViewport()
 
-  const application = await waitForApplication()
-
-  cullInstance.cull(application.renderer.screen)
+  viewport.dirty = true
 }
 
 export function uncull(): void {


### PR DESCRIPTION
# Description
By culling in the `onUpdate` callback we can smoothly animate objects that are leaving or entering the viewport.

Also updates the `cull` method to just set the viewport to dirty to optimize culling. 