### PR TITLE
Make sure we don't render if the nodes are not on the stage

### DIFF
--- a/src/factories/nodeFlowRun.ts
+++ b/src/factories/nodeFlowRun.ts
@@ -31,7 +31,6 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   container.addChild(border)
   container.addChild(bar)
   container.addChild(label)
-  container.addChild(nodesContainer)
   container.addChild(arrowButton)
 
   container.name = DEFAULT_NODE_CONTAINER_NAME

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -46,7 +46,10 @@ export async function nodesContainerFactory() {
   container.name = DEFAULT_NODES_CONTAINER_NAME
 
   emitter.on('layoutUpdated', () => {
-    if (!runData) {
+    // pixi says container.parent will always be a display object but it can be null
+    // if its never been added to a parent
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!runData || container.parent === null) {
       return
     }
 


### PR DESCRIPTION
# Description
Optimizing for nodes that are not rendered so we don't calculate the layout. 