### PR TITLE
Fix horizontal scale object used for viewport date range

### DIFF
--- a/src/objects/scale.ts
+++ b/src/objects/scale.ts
@@ -2,6 +2,7 @@ import { HorizontalScale, horizontalScaleFactory } from '@/factories/position'
 import { horizontalSettingsFactory } from '@/factories/settings'
 import { EventKey, emitter, waitForEvent } from '@/objects/events'
 import { waitForRunData } from '@/objects/nodes'
+import { waitForSettings } from '@/objects/settings'
 
 let scale: HorizontalScale | null = null
 
@@ -26,7 +27,10 @@ export async function waitForScale(): Promise<HorizontalScale> {
   return await waitForEvent('scaleCreated')
 }
 
-function setHorizontalScale(startTime: Date): void {
+async function setHorizontalScale(startTime: Date): Promise<void> {
+  // makes sure the initial horizontal scale multiplier is set prior to creating this scale
+  await waitForSettings()
+
   const event: EventKey = scale ? 'scaleUpdated' : 'scaleCreated'
   const settings = horizontalSettingsFactory(startTime)
 


### PR DESCRIPTION
# Description
Since the layout settings now includes a horizontal scale multiplier if you don't wait for that to be populated the scale will be initialized with a 0 which means the dates will never change. 

Symptom of the chicken and egg scenario of not knowing the original data. Might need to figure out a better way to handle that. But for now this fixes it