### PR TITLE
Ignore temporal scale guide errors

### DIFF
--- a/src/factories/guides.ts
+++ b/src/factories/guides.ts
@@ -2,6 +2,7 @@ import { Container } from 'pixi.js'
 import { DEFAULT_GUIDES_COUNT, DEFAULT_GUIDES_MIN_GAP } from '@/consts'
 import { GuideFactory, guideFactory } from '@/factories/guide'
 import { FormatDate } from '@/models/guides'
+import { NonTemporalLayoutError } from '@/models/nonTemporalLayoutError'
 import { waitForViewport } from '@/objects'
 import { emitter } from '@/objects/events'
 import { waitForScale } from '@/objects/scale'
@@ -37,6 +38,11 @@ export async function guidesFactory() {
 
       renderGuides(times, labelFormat)
     } catch (error) {
+      if (error instanceof NonTemporalLayoutError) {
+        // do nothing. we expect this to happen sometimes
+        return
+      }
+
       console.error(error)
     }
   }
@@ -65,7 +71,7 @@ export async function guidesFactory() {
     const gapDate = scale.invert(left + DEFAULT_GUIDES_MIN_GAP / viewport.scale.x)
 
     if (!(start instanceof Date) || !(gapDate instanceof Date)) {
-      throw new Error('Guides: Attempted to update guides with a non-temporal layout.')
+      throw new NonTemporalLayoutError()
     }
 
     const gap = gapDate.getTime() - start.getTime()

--- a/src/models/nonTemporalLayoutError.ts
+++ b/src/models/nonTemporalLayoutError.ts
@@ -1,0 +1,5 @@
+export class NonTemporalLayoutError extends Error {
+  public constructor() {
+    super('Layout is not temporal')
+  }
+}


### PR DESCRIPTION
# Description
Just ignores a noisy error that we expect to happen when switching between dependency and temporal layouts because event order is not guaranteed. 