### PR TITLE
Only reset the offsets when the layout changes

### DIFF
--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -47,6 +47,8 @@ export async function nodesContainerFactory() {
 
   emitter.on('layoutSettingsUpdated', () => {
     if (Boolean(runData) && Boolean(container.parent)) {
+      rows.clear()
+      columns.clear()
       render(runData!)
     }
   })
@@ -54,8 +56,6 @@ export async function nodesContainerFactory() {
   async function render(data: RunGraphData): Promise<void> {
     runData = data
     nodesLayout = null
-    rows.clear()
-    columns.clear()
 
     await Promise.all([
       createNodes(data),


### PR DESCRIPTION
# Description
When new data is fetched for a run that is in progress the nodes are rendered again. The offsets were being cleared on each render which caused offsets to be removed when they should not have been. Only clearing them when the layout changes fixes that.