### PR TITLE
Fix offsets clearing when settings change

### DIFF
--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -46,11 +46,14 @@ export async function nodesContainerFactory() {
 
   container.name = DEFAULT_NODES_CONTAINER_NAME
 
-  emitter.on('layoutSettingsUpdated', async () => {
-    if (Boolean(runData) && Boolean(container.parent)) {
-      rows.clear()
-      columns.clear()
-      await render(runData!)
+  emitter.on('layoutUpdated', () => {
+    rows.clear()
+    columns.clear()
+  })
+
+  emitter.on('layoutSettingsUpdated', () => {
+    if (runData && Boolean(container.parent)) {
+      render(runData)
     }
 
     highlightSelectedNode()


### PR DESCRIPTION
# Description
`layoutSettingsUpdated` is emitted when any setting is updated. We only want to clear the offsets when the layout modes are changes. Which is the `layoutUpdated` event. So splitting this out a bit