### PR TITLE
Update node axis positions on layout update

### DIFF
--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -327,8 +327,8 @@ export async function nodesContainerFactory() {
         continue
       }
 
-      rows.updateOffsetAxisParameters({ nodeId, axis: nodeLayout.y })
-      columns.updateOffsetAxisParameters({ nodeId, axis: nodeLayout.column })
+      rows.updateOffsetAxis({ nodeId, axis: nodeLayout.y })
+      columns.updateOffsetAxis({ nodeId, axis: nodeLayout.column })
     }
   }
 

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -202,6 +202,9 @@ export async function nodesContainerFactory() {
       const newPosition = getActualPosition(position)
 
       node.setPosition(newPosition)
+
+      rows.updateNodeAxis({ nodeId, axis: position.y })
+      columns.updateNodeAxis({ nodeId, axis: position.column })
     }
 
     renderEdges()
@@ -310,26 +313,7 @@ export async function nodesContainerFactory() {
 
   function handleLayoutMessage(data: WorkerLayoutMessage): void {
     nodesLayout = data.layout
-    updateOffsetAxis()
     setPositions()
-  }
-
-  function updateOffsetAxis(): void {
-    if (!nodesLayout) {
-      return
-    }
-
-    for (const [nodeId] of nodes) {
-      const nodeLayout = nodesLayout.positions.get(nodeId)
-
-      if (!nodeLayout) {
-        console.warn(`Nodes - handleLayoutMessage: Could not find node in layout: Skipping ${nodeId}`)
-        continue
-      }
-
-      rows.updateOffsetAxis({ nodeId, axis: nodeLayout.y })
-      columns.updateOffsetAxis({ nodeId, axis: nodeLayout.column })
-    }
   }
 
   async function highlightSelectedNode(): Promise<void> {

--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -310,7 +310,26 @@ export async function nodesContainerFactory() {
 
   function handleLayoutMessage(data: WorkerLayoutMessage): void {
     nodesLayout = data.layout
+    updateOffsetAxis()
     setPositions()
+  }
+
+  function updateOffsetAxis(): void {
+    if (!nodesLayout) {
+      return
+    }
+
+    for (const [nodeId] of nodes) {
+      const nodeLayout = nodesLayout.positions.get(nodeId)
+
+      if (!nodeLayout) {
+        console.warn(`Nodes - handleLayoutMessage: Could not find node in layout: Skipping ${nodeId}`)
+        continue
+      }
+
+      rows.updateOffsetAxisParameters({ nodeId, axis: nodeLayout.y })
+      columns.updateOffsetAxisParameters({ nodeId, axis: nodeLayout.column })
+    }
   }
 
   async function highlightSelectedNode(): Promise<void> {

--- a/src/factories/offsets.ts
+++ b/src/factories/offsets.ts
@@ -6,6 +6,11 @@ type SetOffsetParameters = {
   offset: number,
 }
 
+type UpdateOffsetAxisParameters = {
+  axis: number,
+  nodeId: string,
+}
+
 type RemoveOffsetParameters = {
   axis: number,
   nodeId: string,
@@ -54,6 +59,27 @@ export function offsetsFactory({ gap = 0, minimum = 0 }: OffsetParameters = {}) 
     offsets.set(axis, value)
   }
 
+  function updateOffsetAxisParameters({ axis, nodeId }: UpdateOffsetAxisParameters): void {
+    let oldAxis
+
+    for (const [key, value] of offsets.entries()) {
+      if (value?.has(nodeId)) {
+        oldAxis = key
+        break
+      }
+    }
+
+    if (oldAxis === undefined || oldAxis === axis) {
+      return
+    }
+
+    const oldAxisOffsets = offsets.get(oldAxis)!
+    const offset = oldAxisOffsets.get(nodeId)!
+
+    oldAxisOffsets.delete(nodeId)
+    setOffset({ axis, nodeId, offset })
+  }
+
   function removeOffset({ axis, nodeId }: RemoveOffsetParameters): void {
     offsets.get(axis)?.delete(nodeId)
   }
@@ -67,6 +93,7 @@ export function offsetsFactory({ gap = 0, minimum = 0 }: OffsetParameters = {}) 
     getTotalOffset,
     getTotalValue,
     setOffset,
+    updateOffsetAxisParameters,
     removeOffset,
     clear,
   }

--- a/src/factories/offsets.ts
+++ b/src/factories/offsets.ts
@@ -59,7 +59,7 @@ export function offsetsFactory({ gap = 0, minimum = 0 }: OffsetParameters = {}) 
     offsets.set(axis, value)
   }
 
-  function updateOffsetAxisParameters({ axis, nodeId }: UpdateOffsetAxisParameters): void {
+  function updateOffsetAxis({ axis, nodeId }: UpdateOffsetAxisParameters): void {
     let oldAxis
 
     for (const [key, value] of offsets.entries()) {
@@ -93,7 +93,7 @@ export function offsetsFactory({ gap = 0, minimum = 0 }: OffsetParameters = {}) 
     getTotalOffset,
     getTotalValue,
     setOffset,
-    updateOffsetAxisParameters,
+    updateOffsetAxis,
     removeOffset,
     clear,
   }

--- a/src/factories/offsets.ts
+++ b/src/factories/offsets.ts
@@ -27,7 +27,7 @@ export type OffsetParameters = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function offsetsFactory({ gap = 0, minimum = 0 }: OffsetParameters = {}) {
-  const offsets: Map<number, Map<string, number> | undefined> = new Map()
+  const offsets: Map<number, Map<string, number>> = new Map()
 
   function getOffset(axis: number): number {
     const values = offsets.get(axis) ?? []
@@ -59,25 +59,24 @@ export function offsetsFactory({ gap = 0, minimum = 0 }: OffsetParameters = {}) 
     offsets.set(axis, value)
   }
 
-  function updateOffsetAxis({ axis, nodeId }: UpdateOffsetAxisParameters): void {
-    let oldAxis
+  function updateNodeAxis({ axis, nodeId }: UpdateOffsetAxisParameters): void {
+    let currentAxis: number | undefined
+    let currentOffset: number | undefined
 
-    for (const [key, value] of offsets.entries()) {
-      if (value?.has(nodeId)) {
-        oldAxis = key
+    for (const [axis, nodes] of offsets.entries()) {
+      if (nodes.has(nodeId)) {
+        currentAxis = axis
+        currentOffset = nodes.get(nodeId)
         break
       }
     }
 
-    if (oldAxis === undefined || oldAxis === axis) {
+    if (currentAxis === axis || currentAxis === undefined || currentOffset === undefined) {
       return
     }
 
-    const oldAxisOffsets = offsets.get(oldAxis)!
-    const offset = oldAxisOffsets.get(nodeId)!
-
-    oldAxisOffsets.delete(nodeId)
-    setOffset({ axis, nodeId, offset })
+    removeOffset({ axis: currentAxis, nodeId })
+    setOffset({ axis, nodeId, offset: currentOffset })
   }
 
   function removeOffset({ axis, nodeId }: RemoveOffsetParameters): void {
@@ -93,7 +92,7 @@ export function offsetsFactory({ gap = 0, minimum = 0 }: OffsetParameters = {}) 
     getTotalOffset,
     getTotalValue,
     setOffset,
-    updateOffsetAxis,
+    updateNodeAxis,
     removeOffset,
     clear,
   }

--- a/src/factories/playhead.ts
+++ b/src/factories/playhead.ts
@@ -24,7 +24,6 @@ export async function playheadFactory() {
       playhead.visible = false
       return
     }
-    console.log('tick')
 
     playhead.width = config.styles.playheadWidth
     playhead.height = application.stage.height


### PR DESCRIPTION
When a new layout message comes in, there's a chance that nodes have shifted into a different row or column. This PR introduces an update check loop when the layout is updated to reset those positions.