### PR TITLE
Remove state name

### DIFF
--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -23,7 +23,6 @@ export type RunGraphNode = {
   kind: RunGraphNodeKind,
   id: string,
   label: string,
-  state_name: string,
   state_type: StateType,
   start_time: Date,
   end_time: Date | null,


### PR DESCRIPTION
# Description
We removed state name from the api so removing it from the type. It is unused