### PR TITLE
Terminate workers when not in use

### DIFF
--- a/src/factories/nodeFlowRun.ts
+++ b/src/factories/nodeFlowRun.ts
@@ -18,7 +18,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   const config = await waitForConfig()
   const { element: bar, render: renderBar } = await nodeBarFactory()
   const { element: label, render: renderLabelText } = await nodeLabelFactory()
-  const { element: nodesContainer, render: renderNodes, getSize: getNodesSize } = await nodesContainerFactory()
+  const { element: nodesContainer, render: renderNodes, getSize: getNodesSize, stopWorker: stopNodesWorker } = await nodesContainerFactory()
   const { element: arrowButton, render: renderArrowButtonContainer } = await nodeArrowButtonFactory()
   const { element: border, render: renderBorderContainer } = await borderFactory()
   const { start: startData, stop: stopData } = await dataFactory(node.id, data => {
@@ -103,6 +103,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   async function close(): Promise<void> {
     isOpen = false
     container.removeChild(nodesContainer)
+    stopNodesWorker()
 
     await Promise.all([
       stopData(),


### PR DESCRIPTION
# Description
Each nodes factory has its own layout worker. But its initializing its worker when it is created. Which means if there are 100 sub flows visible then there are 100 workers. This causes the page to slow down a lot and can even crash the page if there are a lot of subflow runs. 

Initializing the worker only when needed and then manually terminating the worker when its not in use helps a lot with resources and prevents workers that are not doing any work from running. 