### PR TITLE
Fix degraded performance from running nodes

### DIFF
--- a/src/objects/cache.ts
+++ b/src/objects/cache.ts
@@ -1,22 +1,28 @@
-import { Action, ActionArguments, UseSubscription, useSubscription } from '@prefecthq/vue-compositions'
+import { Action } from '@prefecthq/vue-compositions'
 
-let subscriptions: UseSubscription<() => unknown>[] = []
+// Using any here because there isn't much benefit in typing this cache store. The key determines what type of value is returned.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let caches = new Map<string, any>()
 
 export function startCache(): void {
   // do nothing
 }
 
 export function stopCache(): void {
-  subscriptions.forEach(subscription => subscription.unsubscribe())
-  subscriptions = []
+  caches = new Map()
 }
 
-export async function cache<T extends Action>(action: T, parameters: ActionArguments<T>): Promise<ReturnType<T>> {
-  const subscription = useSubscription(action, parameters)
 
-  subscriptions.push(subscription)
+export async function cache<T extends Action>(action: T, parameters: Parameters<T>): Promise<ReturnType<T>> {
+  const key = `${action.toString()}-${JSON.stringify(parameters)}`
 
-  await subscription.promise()
+  if (caches.has(key)) {
+    return caches.get(key)
+  }
 
-  return subscription.response!
+  const value = await action(...parameters)
+
+  caches.set(key, value)
+
+  return value
 }


### PR DESCRIPTION
# Description
As nodes run they render on the application ticker. Each time a node renders it requires a number of textures. Textures which prior to this PR were cached via subscriptions. This caused a problem because even though the graph is a single component, each time a node rendered it would get a unique subscription. So even though the texture was indeed cached. The number of subscriptions would grow by `number of running nodes * number of ticks * number of textures`. 

This caused the number of subscriptions to sky rocket as nodes ran. Slowing down each consecutive node render as the cost for creating a subscription got higher and higher. FPS would degrade slowly and if the nodes ran long enough subscriptions would exceed the stack size. 

Switching from using subscriptions to using a very simple cache with single references per cache fixes this. With this fix I can no longer see the FPS drop even after leaving nodes running for long periods of time. 