### PR TITLE
Fix default multiplier being infinite because of 0 second runs

### DIFF
--- a/src/utilities/getInitialHorizontalScaleMultiplier.ts
+++ b/src/utilities/getInitialHorizontalScaleMultiplier.ts
@@ -3,7 +3,7 @@ import { DEFAULT_TIME_COLUMN_SIZE_PIXELS } from '@/consts'
 import { RequiredGraphConfig, RunGraphData } from '@/models/RunGraph'
 
 export function getInitialHorizontalScaleMultiplier({ start_time, end_time, nodes }: RunGraphData, config: RequiredGraphConfig, aspectRatio: number): number {
-  const seconds = differenceInSeconds(end_time ?? new Date(), start_time)
+  const seconds = Math.max(differenceInSeconds(end_time ?? new Date(), start_time), 1)
 
   const nodeHeight = config.styles.nodeHeight + config.styles.rowGap
   const apxConcurrencyFactor = 0.5


### PR DESCRIPTION
# Description
if the difference between the start_time and end_time of the run is less than 1 second we end up dividing by 0 which produces `INFINITY`. That value get's used for the horizontal scale which messes everything up and produces an empty graph.