### PR TITLE
chore/Update GHA to disallow updating of downstream instances

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,4 @@ jobs:
         with:
           NPM_TOKEN: ${{ secrets.PREFECT_UI_COMPONENTS_NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATE_DOWNSTREAM_REPOS: "false"


### PR DESCRIPTION
- Relates: https://github.com/PrefectHQ/platform/issues/5517
- Just adds the input of `UPDATE_DOWNSTREAM_REPOS` to disallow it to kickoff downstream release jobs since graphs isn't included in the respective `package.json`