### PR TITLE
revert pixi.js and pixi-viewport dependabot bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
         "gsap": "^3.12.2",
         "lodash.isequal": "4.5.0",
         "lodash.merge": "4.6.2",
-        "pixi-viewport": "5.0.2",
-        "pixi.js": "7.3.3"
+        "pixi-viewport": "5.0.1",
+        "pixi.js": "7.3.2"
       },
       "devDependencies": {
         "@prefecthq/eslint-config": "1.0.31",
@@ -622,11 +622,41 @@
         "@pixi/math": "^7.0.0"
       }
     },
+    "node_modules/@pixi/accessibility": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.3.2.tgz",
+      "integrity": "sha512-MdkU22HTauRvq9cMeWZIQGaDDa86sr+m12rKNdLV+FaDQgP/AhP+qCVpK7IKeJa9BrWGXaYMw/vueij7HkyDSA==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/events": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/app": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.3.2.tgz",
+      "integrity": "sha512-3YRFSMvAxDebAz3/JJv+2jzbPkT8cHC0IHmmLRN8krDL1pZV+YjMLgMwN/Oeyv5TSbwNqnrF5su5whNkRaxeZQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/assets": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.3.2.tgz",
+      "integrity": "sha512-yteq6ptAxA09EcwU9D9hl7qr5yWIqy+c2PsXkTDkc76vTAwIamLY3KxLq2aR5y1U4L4O6aHFJd26uNhHcuTPmw==",
+      "dependencies": {
+        "@types/css-font-loading-module": "^0.0.7"
+      },
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/utils": "7.3.2"
+      }
+    },
     "node_modules/@pixi/color": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.3.2.tgz",
       "integrity": "sha512-jur5PvdOtUBEUTjmPudW5qdQq6yYGlVGsi3HyhasJw14bN+GKJwiCKgIsyrsiNL5HBUXmje4ICwQohf6BqKqxA==",
-      "peer": true,
       "dependencies": {
         "@pixi/colord": "^2.9.6"
       }
@@ -636,17 +666,24 @@
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
       "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
     },
+    "node_modules/@pixi/compressed-textures": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.3.2.tgz",
+      "integrity": "sha512-J3ENMHDPQO6CJRei55gqI0WmiZJIK6SgsW5AEkShT0aAe5miEBSomv70pXw/58ru+4/Hx8cXjamsGt4aQB2D0Q==",
+      "peerDependencies": {
+        "@pixi/assets": "7.3.2",
+        "@pixi/core": "7.3.2"
+      }
+    },
     "node_modules/@pixi/constants": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.3.2.tgz",
-      "integrity": "sha512-Q8W3ncsFxmfgC5EtokpG92qJZabd+Dl+pbQAdHwiPY3v+8UNq77u4VN2qtl1Z04864hCcg7AStIYEDrzqTLF6Q==",
-      "peer": true
+      "integrity": "sha512-Q8W3ncsFxmfgC5EtokpG92qJZabd+Dl+pbQAdHwiPY3v+8UNq77u4VN2qtl1Z04864hCcg7AStIYEDrzqTLF6Q=="
     },
     "node_modules/@pixi/core": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.3.2.tgz",
       "integrity": "sha512-Pta3ee8MtJ3yKxGXzglBWgwbEOKMB6Eth+FpLTjL0rgxiqTB550YX6jsNEQQAzcGjCBlO3rC/IF57UZ2go/X6w==",
-      "peer": true,
       "dependencies": {
         "@pixi/color": "7.3.2",
         "@pixi/constants": "7.3.2",
@@ -667,45 +704,249 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.3.2.tgz",
       "integrity": "sha512-cY5AnZ3TWt5GYGx4e5AQ2/2U9kP+RorBg/O30amJ+8e9bFk9rS8cjh/DDq/hc4lql96BkXAInTl40eHnAML5lQ==",
-      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/events": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.3.2.tgz",
+      "integrity": "sha512-Moca9epu8jk1wIQCdVYjhz2pD9Ol21m50wvWUKvpgt9yM/AjkCLSDt8HO/PmTpavDrkhx5pVVWeDDA6FyUNaGA==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2"
       }
     },
     "node_modules/@pixi/extensions": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.3.2.tgz",
-      "integrity": "sha512-Qw84ADfvmVu4Mwj+zTik/IEEK9lWS5n4trbrpQCcEZ+Mb8oRAXWvKz199mi1s7+LaZXDqeCY1yr2PHQaFf1KBA==",
-      "peer": true
+      "integrity": "sha512-Qw84ADfvmVu4Mwj+zTik/IEEK9lWS5n4trbrpQCcEZ+Mb8oRAXWvKz199mi1s7+LaZXDqeCY1yr2PHQaFf1KBA=="
+    },
+    "node_modules/@pixi/extract": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.3.2.tgz",
+      "integrity": "sha512-KsoflvQZV/XD8A8xbtRnmI4reYekbI4MOi7ilwQe5tMz6O1mO7IzrSukxkSMD02f6SpbAqbi7a1EayTjvY0ECQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-alpha": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.3.2.tgz",
+      "integrity": "sha512-nZMdn310wH5ZK1slwv3X4qT8eLoAGO7SgYGCy5IsMtpCtNObzE9XA4tAfhXrjihyzPS9KvszgAbnv1Qpfh0/uw==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-blur": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.3.2.tgz",
+      "integrity": "sha512-unu3zhwHMhN+iAe7Td2rK40i2UJ2GOhzWK+6jcU3ZkMOsFCT5kgBoMRTejeQVcvCs6GoYK8imbkE7mXt05Vj6A==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-color-matrix": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.3.2.tgz",
+      "integrity": "sha512-rbyjes/9SMoV9jjPiK0sLMkmLfN8D17GoTJIfq/KLv1x9646W5fL2QSKkN04UkZ+020ndWvIOxK1S97tvRyCfg==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-displacement": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.3.2.tgz",
+      "integrity": "sha512-ZHl7Sfb8JYd9Z6j96OHCC0NhMKhhXJRE5AbkSDohjEMVCK1BV5rDGAHV8WVt/2MJ/j83CXUpydzyMhdM4lMchg==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-fxaa": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.3.2.tgz",
+      "integrity": "sha512-9brtlxDnQTZk2XiFBKdBK9e+8CX9LdxxcL7LRpjEyiHuAPvTlQgu9B85LrJ4GzWKqJJKaIIZBzhIoiCLUnfeXg==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/filter-noise": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.3.2.tgz",
+      "integrity": "sha512-F8GQQ20n7tCjThX6GCXckiXz2YffOCxicTJ0oat9aVDZh+sVsAxYX0aKSdHh0hhv18F0yuc6tPsSL5DYb63xFg==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/graphics": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.3.2.tgz",
+      "integrity": "sha512-PhU6j1yub4tH/s+/gqByzgZ3mLv1mfb6iGXbquycg3+WypcxHZn0opFtI/axsazaQ9SEaWxw1m3i40WG5ANH5g==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
     },
     "node_modules/@pixi/math": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.3.2.tgz",
-      "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w==",
-      "peer": true
+      "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w=="
+    },
+    "node_modules/@pixi/mesh": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.3.2.tgz",
+      "integrity": "sha512-LFkt7ELYXQLgbgHpjl68j6JD5ejUwma8zoPn2gqSBbY+6pK/phjvV1Wkh76muF46VvNulgXF0+qLIDdCsfrDaA==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/mesh-extras": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.3.2.tgz",
+      "integrity": "sha512-s/tg9TsTZZxLEdCDKWnBChDGkc041HCTP7ykJv4fEROzb9B0lskULYyvv+/YNNKa2Ugb9WnkMknpOdOXCpjyyg==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/mesh": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/mixin-cache-as-bitmap": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.3.2.tgz",
+      "integrity": "sha512-bZRlyUN5+9kCUjn67V0IFtYIrbmx9Vs4sMOmXyrX3Q4B4gPLE46IzZz3v0IVaTjp32udlQztfJalIaWbuqgb3A==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/mixin-get-child-by-name": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.3.2.tgz",
+      "integrity": "sha512-mbUi3WxXrkViH7qOgjk4fu2BN36NwNb7u+Fy1J5dS8Bntj57ZVKmEV9PbUy0zYjXE8rVmeAvSu/2kbn5n9UutQ==",
+      "peerDependencies": {
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/mixin-get-global-position": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.3.2.tgz",
+      "integrity": "sha512-1nhWbBgmw6rK7yQJxzeI9yjKYYEkM5i3pee8qVu4YWo3b1xWVQA7osQG7aGM/4qywDkXaA1ZvciA5hfg6f4Q5Q==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/particle-container": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.3.2.tgz",
+      "integrity": "sha512-JYc4j4z97KmxyLp+1Lg0SNi8hy6RxcBBNQGk+CSLNXeDWxx3hykT5gj/ORX1eXyzHh1ZCG1XzeVS9Yr8QhlFHA==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/prepare": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.3.2.tgz",
+      "integrity": "sha512-aLPAXSYLUhMwxzJtn9m0TSZe+dQlZCt09QNBqYbSi8LZId54QMDyvfBb4zBOJZrD2xAZgYL5RIJuKHwZtFX6lQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/graphics": "7.3.2",
+        "@pixi/text": "7.3.2"
+      }
     },
     "node_modules/@pixi/runner": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.3.2.tgz",
-      "integrity": "sha512-maKotoKJCQiQGBJwfM+iYdQKjrPN/Tn9+72F4WIf706zp/5vKoxW688Rsktg5BX4Mcn7ZkZvcJYTxj2Mv87lFA==",
-      "peer": true
+      "integrity": "sha512-maKotoKJCQiQGBJwfM+iYdQKjrPN/Tn9+72F4WIf706zp/5vKoxW688Rsktg5BX4Mcn7ZkZvcJYTxj2Mv87lFA=="
     },
     "node_modules/@pixi/settings": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.3.2.tgz",
       "integrity": "sha512-vtxzuARDTbFe0fRYSqB53B+mPpX7v+QjjnCUmVMVvZiWr3QcngMWVml6c6dQDln7IakWoKZRrNG4FpggvDgLVg==",
-      "peer": true,
       "dependencies": {
         "@pixi/constants": "7.3.2",
         "@types/css-font-loading-module": "^0.0.7",
         "ismobilejs": "^1.1.0"
       }
     },
+    "node_modules/@pixi/sprite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.3.2.tgz",
+      "integrity": "sha512-IpWTKXExJNXVcY7ITopJ+JW48DahdbCo/81D2IYzBImq3jyiJM2Km5EoJgvAM5ZQ3Ev3KPPIBzYLD+HoPWcxdw==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/sprite-animated": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.3.2.tgz",
+      "integrity": "sha512-j9pyUe4cefxE9wecNfbWQyL5fBQKvCGYaOA0DE1X46ukBHrIuhA8u3jg2X3N3r4IcbVvxpWFYDrDsWXWeiBmSw==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/sprite-tiling": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.3.2.tgz",
+      "integrity": "sha512-tWVVb/rMIx5AczfUrVxa0dZaIufP5C0IOL7IGfFUDQqDu5JSAUC0mwLe4F12jAXBVsqYhCGYx5bIHbPiI5vcSQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/spritesheet": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.3.2.tgz",
+      "integrity": "sha512-UkwqrPYDqrEdK5ub9qn/9VBvt5caA8ffV5iYR6ssCvrpaQovBKmS+b5pr/BYf8xNTExDpR3OmPIo8iDEYWWLuw==",
+      "peerDependencies": {
+        "@pixi/assets": "7.3.2",
+        "@pixi/core": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/text": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.3.2.tgz",
+      "integrity": "sha512-LdtNj+K5tPB/0UcDcO52M/C7xhwFTGFhtdF42fPhRuJawM23M3zm1Y8PapXv+mury+IxCHT1w30YlAi0qTVpKQ==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/sprite": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/text-bitmap": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.3.2.tgz",
+      "integrity": "sha512-p8KLgtZSPowWU/Zj+GVtfsUT8uGYo4TtKKYbLoWuxkRA5Pc1+4C9/rV/EOSFfoZIdW5C+iFg5VxRgBllUQf+aA==",
+      "peerDependencies": {
+        "@pixi/assets": "7.3.2",
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/mesh": "7.3.2",
+        "@pixi/text": "7.3.2"
+      }
+    },
+    "node_modules/@pixi/text-html": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.3.2.tgz",
+      "integrity": "sha512-IYhBWEPOvqUtlHkS5/c1Hseuricj5jrrGd21ivcvHmcnK/x2m+CRGvvzeBp1mqoYBnDbQVrD2wSXSe4Dv9tEJA==",
+      "peerDependencies": {
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/sprite": "7.3.2",
+        "@pixi/text": "7.3.2"
+      }
+    },
     "node_modules/@pixi/ticker": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.3.2.tgz",
       "integrity": "sha512-5kIPhBeXwDJohCzKzJJ6T7f1oAGbHAgeiwOjlTO+9lNXUX8ZPj0407V3syuF+64kFqJzIBCznBRpI+fmT4c9SA==",
-      "peer": true,
       "dependencies": {
         "@pixi/extensions": "7.3.2",
         "@pixi/settings": "7.3.2",
@@ -716,7 +957,6 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.3.2.tgz",
       "integrity": "sha512-KhNvj9YcY7Zi2dTKZgDpx8C6OxKKR541vwtG6JgdBZZYDeMBOIghN2Vi5zn4diW5BhDfHBmdSJ1wZXEtE2MDwg==",
-      "peer": true,
       "dependencies": {
         "@pixi/color": "7.3.2",
         "@pixi/constants": "7.3.2",
@@ -1230,8 +1470,7 @@
     "node_modules/@types/css-font-loading-module": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
-      "peer": true
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="
     },
     "node_modules/@types/d3": {
       "version": "7.4.3",
@@ -5572,394 +5811,50 @@
       }
     },
     "node_modules/pixi-viewport": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-5.0.2.tgz",
-      "integrity": "sha512-U77KnCTl81xEgxEQRFEuI7MYVySWwCVkA41EnM8KiOYwgVOwdBUa7318O+u61IOnTwnoYLzaihy/kpoONKU13Q=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-5.0.1.tgz",
+      "integrity": "sha512-fIILU9xztqGnhGF5SYfjn1Rir/7asWkJ8zSUay2hwzPrdGTWFtB4yiIlZDeFaLf7KHA04RRb2kI01Sy1kNksAw=="
     },
     "node_modules/pixi.js": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.3.3.tgz",
-      "integrity": "sha512-EuAyWZBL5lKViCgYkB6dbwkiI/MNht8O8F8956up9vwGEGf659QRHxfVQoRj8zdNGOBbe51XAxQMfLaW/l0Ekg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.3.2.tgz",
+      "integrity": "sha512-GJickUrT3UcBInGT1CU6cv2oktCdocE5QM74CD3t+weiJPPWIzleNlp7zrBR5QIDdU6bEO8CUgUXH2Y9QvlCMw==",
       "dependencies": {
-        "@pixi/accessibility": "7.3.3",
-        "@pixi/app": "7.3.3",
-        "@pixi/assets": "7.3.3",
-        "@pixi/compressed-textures": "7.3.3",
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3",
-        "@pixi/events": "7.3.3",
-        "@pixi/extensions": "7.3.3",
-        "@pixi/extract": "7.3.3",
-        "@pixi/filter-alpha": "7.3.3",
-        "@pixi/filter-blur": "7.3.3",
-        "@pixi/filter-color-matrix": "7.3.3",
-        "@pixi/filter-displacement": "7.3.3",
-        "@pixi/filter-fxaa": "7.3.3",
-        "@pixi/filter-noise": "7.3.3",
-        "@pixi/graphics": "7.3.3",
-        "@pixi/mesh": "7.3.3",
-        "@pixi/mesh-extras": "7.3.3",
-        "@pixi/mixin-cache-as-bitmap": "7.3.3",
-        "@pixi/mixin-get-child-by-name": "7.3.3",
-        "@pixi/mixin-get-global-position": "7.3.3",
-        "@pixi/particle-container": "7.3.3",
-        "@pixi/prepare": "7.3.3",
-        "@pixi/sprite": "7.3.3",
-        "@pixi/sprite-animated": "7.3.3",
-        "@pixi/sprite-tiling": "7.3.3",
-        "@pixi/spritesheet": "7.3.3",
-        "@pixi/text": "7.3.3",
-        "@pixi/text-bitmap": "7.3.3",
-        "@pixi/text-html": "7.3.3"
+        "@pixi/accessibility": "7.3.2",
+        "@pixi/app": "7.3.2",
+        "@pixi/assets": "7.3.2",
+        "@pixi/compressed-textures": "7.3.2",
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/events": "7.3.2",
+        "@pixi/extensions": "7.3.2",
+        "@pixi/extract": "7.3.2",
+        "@pixi/filter-alpha": "7.3.2",
+        "@pixi/filter-blur": "7.3.2",
+        "@pixi/filter-color-matrix": "7.3.2",
+        "@pixi/filter-displacement": "7.3.2",
+        "@pixi/filter-fxaa": "7.3.2",
+        "@pixi/filter-noise": "7.3.2",
+        "@pixi/graphics": "7.3.2",
+        "@pixi/mesh": "7.3.2",
+        "@pixi/mesh-extras": "7.3.2",
+        "@pixi/mixin-cache-as-bitmap": "7.3.2",
+        "@pixi/mixin-get-child-by-name": "7.3.2",
+        "@pixi/mixin-get-global-position": "7.3.2",
+        "@pixi/particle-container": "7.3.2",
+        "@pixi/prepare": "7.3.2",
+        "@pixi/sprite": "7.3.2",
+        "@pixi/sprite-animated": "7.3.2",
+        "@pixi/sprite-tiling": "7.3.2",
+        "@pixi/spritesheet": "7.3.2",
+        "@pixi/text": "7.3.2",
+        "@pixi/text-bitmap": "7.3.2",
+        "@pixi/text-html": "7.3.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
       }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/accessibility": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.3.3.tgz",
-      "integrity": "sha512-cHiIEP54RNqvPKmi45HvvnTbiWU+/lzdTY0zK7OXx3TmcEQRn2A7GZ1I+uxx476NeXGJtGSvv3copyxFjPB6Ew==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3",
-        "@pixi/events": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/app": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.3.3.tgz",
-      "integrity": "sha512-MS5r/yU0CrWMPXXrgKAzgC2KC35Och8fT9z6J1XUCs7yHhdO8768rnSePJuzhj9Yaclv7PUpNQzh8rG9o/MzkQ==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/assets": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.3.3.tgz",
-      "integrity": "sha512-KcLXVehdJ2kc2bSnTfatLPLL6sLD7dwU+EZ5bWQ/PZDSsfML3kLFvq84VXd4k8LKNX4RCvfy4yeeIUW1o5tnMg==",
-      "dependencies": {
-        "@types/css-font-loading-module": "^0.0.12"
-      },
-      "peerDependencies": {
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/color": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.3.3.tgz",
-      "integrity": "sha512-IiiFhNIqXt7yULe0Wkq5Hn38ymDoEen/6EvV2y2AQIOu6TyuET5PGswAdMfG7ZjfwBaCudK6yQEUjWaXbgRUmw==",
-      "dependencies": {
-        "@pixi/colord": "^2.9.6"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/compressed-textures": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.3.3.tgz",
-      "integrity": "sha512-4h1NKePF5blN7qux29yEnKiGdk4vZif59XtLviW7Y3r9MKgKSoizDl0RqU4SKo4eC1P0jpt1qOjiG4TE+AjXGQ==",
-      "peerDependencies": {
-        "@pixi/assets": "7.3.3",
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/constants": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.3.3.tgz",
-      "integrity": "sha512-ww1JdekmKBUqHyPq8A5L+86FkzpS4KidlBm9wkX1fcd+6QQzq/vbx1JOz6m3CmH5LnlmDZ+zysLezvpZlBcwwA=="
-    },
-    "node_modules/pixi.js/node_modules/@pixi/core": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.3.3.tgz",
-      "integrity": "sha512-064tuK6NoGIl/2Wf4EUlaLLlnRMZuDdLqnISsj2/A70towg2QUWgHhwZsCB4NvAssidWu/sIT+vk5IKDmh1LKA==",
-      "dependencies": {
-        "@pixi/color": "7.3.3",
-        "@pixi/constants": "7.3.3",
-        "@pixi/extensions": "7.3.3",
-        "@pixi/math": "7.3.3",
-        "@pixi/runner": "7.3.3",
-        "@pixi/settings": "7.3.3",
-        "@pixi/ticker": "7.3.3",
-        "@pixi/utils": "7.3.3",
-        "@types/offscreencanvas": "^2019.6.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/display": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.3.3.tgz",
-      "integrity": "sha512-iULZ2E6Z4vhI0FypXpUbtA+CODnj/CuTt2pi9gsw00ILI12eEx76cAiazvhxnCNqcfmj1RRK2P6s9Vzr5WmEIg==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/events": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.3.3.tgz",
-      "integrity": "sha512-1oDfdFtKsy0Z9ew09MrSYGIIeGnBXr/c7866A32Od3KXql0dhd7UpFFpaFKLCXydDHRgFkjOP7t0/Pp1luTvfg==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/extensions": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.3.3.tgz",
-      "integrity": "sha512-Of44Wde0ZHYCuMoDLFl/8SOSPV2NiDBUB6QKBvYvNdhVslbO3pxrn9oQH9Fmsd8iGcGJ/YtyI5H2T/ky4Bo6AQ=="
-    },
-    "node_modules/pixi.js/node_modules/@pixi/extract": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.3.3.tgz",
-      "integrity": "sha512-quD61mNtgq3w2USIPUBOuxD9kVWIPoh8offqJugT4ZZS2XlSnh2FvLjCEC66jVmMM0tmk6HGAfc5xRFNlyw8PQ==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-alpha": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.3.3.tgz",
-      "integrity": "sha512-StLLxEkCyghK3dhzLZD9jMu4lZ/ir4Bah2XXXWGhwE+XCO+//rnXreZ8v74R52WbaLUNDHzwlbq7/+BABwMu5w==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-blur": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.3.3.tgz",
-      "integrity": "sha512-AZzMbcFoL+uHxiVM2nQrQM0MQdLdd5mw7Fd4F60ROB96tmMK/M5W/FTqgdqXUQYld6wCFZKtJMulonVaPKLXDA==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-color-matrix": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.3.3.tgz",
-      "integrity": "sha512-Ot9lQ24lff4DPok0qy+c3IekfEuGf0Y1mx/dB3iLceys2hJHF5wK8rrhKrA1vc5IgrirbZpmjK8it9cVFzEW2g==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-displacement": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.3.3.tgz",
-      "integrity": "sha512-fBnZTUmt6wwazdk/ZDW3HJEkf9s5b8uDuOwHvUAPWTJ6oYqwAjFXnrTlhEwB/Fp+0v6hUVVlHWEYk07HVgjEIg==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-fxaa": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.3.3.tgz",
-      "integrity": "sha512-xq5xcpu68axMrGsVOcpxqebLAa+B4yBSLQlI2rsn7s8YtWY+pC20lsaNnKDlrv9hwJ1Ah7BtBZy0EVVaeFNYqA==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/filter-noise": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.3.3.tgz",
-      "integrity": "sha512-Hwwk1xLvA+0wTqJtKTnIGzyZmLubm5ylgqsMRHQqujDtVSIqE2SY1iVUcGA5vv31C7rFFkxGT4yhtfnYBNCvKQ==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/graphics": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.3.3.tgz",
-      "integrity": "sha512-czX/SEQTSCI3kkH5DFAcchPaPYOAF7cz1P5K2hVvClE/bbbIWN0H2sBIF6pIY1ENkZ0aguQs36yDeXUDWXyoiQ==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3",
-        "@pixi/sprite": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/math": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.3.3.tgz",
-      "integrity": "sha512-kaHN6iusINPS0wIbrhP82za+B2qNDWHPHip/QtmpQTp81ibOIfHlDMOlsnE6rSdelTFNhrNWoTWU8IvXUbvy8g=="
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mesh": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.3.3.tgz",
-      "integrity": "sha512-8G3FO44wLDimNlCqXBKF+zQ3nBqJ4kMBbIjGxRaRkJmahcMYkY2zJpYsYh1YqKQztL9UmcP5V170VEIcPsmaJw==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mesh-extras": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.3.3.tgz",
-      "integrity": "sha512-2TW1n97PpSZIZomfoEcKezGeGLPyd82ng2u8SXQoy9keCmB2yK361/RO88jvWbY4qpnJn/89LiLyYEBiJtSmWg==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/mesh": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.3.3.tgz",
-      "integrity": "sha512-Vv/H24CADY5w2DZaTYhXsfr8wAyKsg6gYn0DLgWDnAI3PWkRcB0fVDfowlHAEzltfxyH4tp9LVc2jtbEIKfSlQ==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3",
-        "@pixi/sprite": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.3.3.tgz",
-      "integrity": "sha512-75vlViVaynPyIYQIaoU08k1iP+8s9ct2YEnW91vyiHGxxE7BBimiYomWkAUYXtSnaSFoDkNPOh7iI91Icmkf+w==",
-      "peerDependencies": {
-        "@pixi/display": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/mixin-get-global-position": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.3.3.tgz",
-      "integrity": "sha512-ZEScRlx/KSr0z40+xqF9jl9N8j0aFZCNwSluoMLuFecvn4kpaCQx8i4F8j+GkkdrnCfanSYE9ySADlUCsKmzHA==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/particle-container": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.3.3.tgz",
-      "integrity": "sha512-OxigacwSbPjVogahmBYUiYMIH+NhNa+jvGAk5OYEF431gcVmjtravPbk7mmFdGKmOMICztSyVX8kOyhXxCv63A==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3",
-        "@pixi/sprite": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/prepare": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.3.3.tgz",
-      "integrity": "sha512-2SdTyHJSDZeaEMuxXqOX01FUDhIjfWUmVCufLXxzjd8gZ52RWBpohl2gDRszPJMyPox142xzUiCnb4RuNXGHDw==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3",
-        "@pixi/graphics": "7.3.3",
-        "@pixi/text": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/runner": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.3.3.tgz",
-      "integrity": "sha512-LUObHyxM3tK504ChbioYySZhFhyNs779uA71fuWSFV04Ry0WNlbqVvwTbKGkyR6er6blfxdqk7d51WmuQtfLCg=="
-    },
-    "node_modules/pixi.js/node_modules/@pixi/settings": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.3.3.tgz",
-      "integrity": "sha512-a1OePduDPOfnrCm1U1RL7JhuEAncA5/jNwF51urclXU6HNTHiJT41/S6KELPoV8NbLyJCKtnKwzbbPkzKwc0Yg==",
-      "dependencies": {
-        "@pixi/constants": "7.3.3",
-        "@types/css-font-loading-module": "^0.0.12",
-        "ismobilejs": "^1.1.0"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.3.3.tgz",
-      "integrity": "sha512-P/RxnvNV0PiuyaT9HA8F1aX9krp1BgjllBQcn6KHVxyAP8tJE0TD9pfHOU1+xRuoX37swXRQiDFTF6YvWzozUQ==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite-animated": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.3.3.tgz",
-      "integrity": "sha512-BYvehHk3PlNln9tRfZ/zGp2MzVwRjggFe+s4NCQd1EU/NPQewqJGCAiQFB4Gc3hFK2Y8wkW7SpGAzuk/E2WTxg==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/sprite": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/sprite-tiling": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.3.3.tgz",
-      "integrity": "sha512-T4ms0TcfKq7JNRaUBaQyZsaxWziPh2EY10vFQEG17J3uyCrjQmN4dDS9AMoaltL1K3vh+CTSUnWO8S8mE1dn4Q==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3",
-        "@pixi/sprite": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/spritesheet": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.3.3.tgz",
-      "integrity": "sha512-aAebizGNiKijWmJ39bnAb8FbuXbxRINuWZ2xt7ANzJQxhbo7dX+qlF4pz91yj3gHQaulzJM2oKz4a5q6cHa7dw==",
-      "peerDependencies": {
-        "@pixi/assets": "7.3.3",
-        "@pixi/core": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.3.3.tgz",
-      "integrity": "sha512-s9BLmiURYeJppPYB040jrGbtbsWM9PcXSRtr40xrbR0a+HPlxDEWCaHka9DiUFr/lIuOpA0y/YjmZskq5o5R7g==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/sprite": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text-bitmap": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.3.3.tgz",
-      "integrity": "sha512-2IOBoSHtb2e1aoxB/pfJPFW34XeY8HpDtGJKn3F9IUYpBo6nnnZ6DuJNZyFG2r/hiytjVvulqI66CzOH/eJJ4A==",
-      "peerDependencies": {
-        "@pixi/assets": "7.3.3",
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3",
-        "@pixi/mesh": "7.3.3",
-        "@pixi/text": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/text-html": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.3.3.tgz",
-      "integrity": "sha512-z8vsgsqVJuFEVX07wh0IYAwQ5DBiel8Lhxo2Ly8594O0mIdQ1IPvtAPv+WRyG35WT0i26J7GL2BZxURouDP2WA==",
-      "peerDependencies": {
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3",
-        "@pixi/sprite": "7.3.3",
-        "@pixi/text": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/ticker": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.3.3.tgz",
-      "integrity": "sha512-AxeMKP9vTcla+yYXCABc0uKUODjIsJRXk3DCHVpoPeeqRYPaKH291RtDw92QFw7FFgGBbRgsptBjF9Q+uO5hDA==",
-      "dependencies": {
-        "@pixi/extensions": "7.3.3",
-        "@pixi/settings": "7.3.3",
-        "@pixi/utils": "7.3.3"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@pixi/utils": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.3.3.tgz",
-      "integrity": "sha512-rgWD0YV6oDKOVuQJ9ra6g3VdoN8usC6Kj/t3Ba1t9P+k9qUKIM0gCr9/bxFf7CJ/EUS8A2WTVfEmJVN2TwZfxg==",
-      "dependencies": {
-        "@pixi/color": "7.3.3",
-        "@pixi/constants": "7.3.3",
-        "@pixi/settings": "7.3.3",
-        "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
-        "eventemitter3": "^4.0.0",
-        "url": "^0.11.0"
-      }
-    },
-    "node_modules/pixi.js/node_modules/@types/css-font-loading-module": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
-      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA=="
     },
     "node_modules/plimit-lit": {
       "version": "1.5.0",
@@ -7794,11 +7689,30 @@
       "integrity": "sha512-6hm1wfCmGItOnyKvCxrmZmOLQVIaN0MqseBweH+tLZH8ecGTIF3qb1cGQDNf9jaK6HH7s/+7m9xXvvk9e92ESw==",
       "requires": {}
     },
+    "@pixi/accessibility": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.3.2.tgz",
+      "integrity": "sha512-MdkU22HTauRvq9cMeWZIQGaDDa86sr+m12rKNdLV+FaDQgP/AhP+qCVpK7IKeJa9BrWGXaYMw/vueij7HkyDSA==",
+      "requires": {}
+    },
+    "@pixi/app": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.3.2.tgz",
+      "integrity": "sha512-3YRFSMvAxDebAz3/JJv+2jzbPkT8cHC0IHmmLRN8krDL1pZV+YjMLgMwN/Oeyv5TSbwNqnrF5su5whNkRaxeZQ==",
+      "requires": {}
+    },
+    "@pixi/assets": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.3.2.tgz",
+      "integrity": "sha512-yteq6ptAxA09EcwU9D9hl7qr5yWIqy+c2PsXkTDkc76vTAwIamLY3KxLq2aR5y1U4L4O6aHFJd26uNhHcuTPmw==",
+      "requires": {
+        "@types/css-font-loading-module": "^0.0.7"
+      }
+    },
     "@pixi/color": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.3.2.tgz",
       "integrity": "sha512-jur5PvdOtUBEUTjmPudW5qdQq6yYGlVGsi3HyhasJw14bN+GKJwiCKgIsyrsiNL5HBUXmje4ICwQohf6BqKqxA==",
-      "peer": true,
       "requires": {
         "@pixi/colord": "^2.9.6"
       }
@@ -7808,17 +7722,21 @@
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
       "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
     },
+    "@pixi/compressed-textures": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.3.2.tgz",
+      "integrity": "sha512-J3ENMHDPQO6CJRei55gqI0WmiZJIK6SgsW5AEkShT0aAe5miEBSomv70pXw/58ru+4/Hx8cXjamsGt4aQB2D0Q==",
+      "requires": {}
+    },
     "@pixi/constants": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.3.2.tgz",
-      "integrity": "sha512-Q8W3ncsFxmfgC5EtokpG92qJZabd+Dl+pbQAdHwiPY3v+8UNq77u4VN2qtl1Z04864hCcg7AStIYEDrzqTLF6Q==",
-      "peer": true
+      "integrity": "sha512-Q8W3ncsFxmfgC5EtokpG92qJZabd+Dl+pbQAdHwiPY3v+8UNq77u4VN2qtl1Z04864hCcg7AStIYEDrzqTLF6Q=="
     },
     "@pixi/core": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.3.2.tgz",
       "integrity": "sha512-Pta3ee8MtJ3yKxGXzglBWgwbEOKMB6Eth+FpLTjL0rgxiqTB550YX6jsNEQQAzcGjCBlO3rC/IF57UZ2go/X6w==",
-      "peer": true,
       "requires": {
         "@pixi/color": "7.3.2",
         "@pixi/constants": "7.3.2",
@@ -7835,43 +7753,175 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.3.2.tgz",
       "integrity": "sha512-cY5AnZ3TWt5GYGx4e5AQ2/2U9kP+RorBg/O30amJ+8e9bFk9rS8cjh/DDq/hc4lql96BkXAInTl40eHnAML5lQ==",
-      "peer": true,
+      "requires": {}
+    },
+    "@pixi/events": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.3.2.tgz",
+      "integrity": "sha512-Moca9epu8jk1wIQCdVYjhz2pD9Ol21m50wvWUKvpgt9yM/AjkCLSDt8HO/PmTpavDrkhx5pVVWeDDA6FyUNaGA==",
       "requires": {}
     },
     "@pixi/extensions": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.3.2.tgz",
-      "integrity": "sha512-Qw84ADfvmVu4Mwj+zTik/IEEK9lWS5n4trbrpQCcEZ+Mb8oRAXWvKz199mi1s7+LaZXDqeCY1yr2PHQaFf1KBA==",
-      "peer": true
+      "integrity": "sha512-Qw84ADfvmVu4Mwj+zTik/IEEK9lWS5n4trbrpQCcEZ+Mb8oRAXWvKz199mi1s7+LaZXDqeCY1yr2PHQaFf1KBA=="
+    },
+    "@pixi/extract": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.3.2.tgz",
+      "integrity": "sha512-KsoflvQZV/XD8A8xbtRnmI4reYekbI4MOi7ilwQe5tMz6O1mO7IzrSukxkSMD02f6SpbAqbi7a1EayTjvY0ECQ==",
+      "requires": {}
+    },
+    "@pixi/filter-alpha": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.3.2.tgz",
+      "integrity": "sha512-nZMdn310wH5ZK1slwv3X4qT8eLoAGO7SgYGCy5IsMtpCtNObzE9XA4tAfhXrjihyzPS9KvszgAbnv1Qpfh0/uw==",
+      "requires": {}
+    },
+    "@pixi/filter-blur": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.3.2.tgz",
+      "integrity": "sha512-unu3zhwHMhN+iAe7Td2rK40i2UJ2GOhzWK+6jcU3ZkMOsFCT5kgBoMRTejeQVcvCs6GoYK8imbkE7mXt05Vj6A==",
+      "requires": {}
+    },
+    "@pixi/filter-color-matrix": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.3.2.tgz",
+      "integrity": "sha512-rbyjes/9SMoV9jjPiK0sLMkmLfN8D17GoTJIfq/KLv1x9646W5fL2QSKkN04UkZ+020ndWvIOxK1S97tvRyCfg==",
+      "requires": {}
+    },
+    "@pixi/filter-displacement": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.3.2.tgz",
+      "integrity": "sha512-ZHl7Sfb8JYd9Z6j96OHCC0NhMKhhXJRE5AbkSDohjEMVCK1BV5rDGAHV8WVt/2MJ/j83CXUpydzyMhdM4lMchg==",
+      "requires": {}
+    },
+    "@pixi/filter-fxaa": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.3.2.tgz",
+      "integrity": "sha512-9brtlxDnQTZk2XiFBKdBK9e+8CX9LdxxcL7LRpjEyiHuAPvTlQgu9B85LrJ4GzWKqJJKaIIZBzhIoiCLUnfeXg==",
+      "requires": {}
+    },
+    "@pixi/filter-noise": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.3.2.tgz",
+      "integrity": "sha512-F8GQQ20n7tCjThX6GCXckiXz2YffOCxicTJ0oat9aVDZh+sVsAxYX0aKSdHh0hhv18F0yuc6tPsSL5DYb63xFg==",
+      "requires": {}
+    },
+    "@pixi/graphics": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.3.2.tgz",
+      "integrity": "sha512-PhU6j1yub4tH/s+/gqByzgZ3mLv1mfb6iGXbquycg3+WypcxHZn0opFtI/axsazaQ9SEaWxw1m3i40WG5ANH5g==",
+      "requires": {}
     },
     "@pixi/math": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.3.2.tgz",
-      "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w==",
-      "peer": true
+      "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w=="
+    },
+    "@pixi/mesh": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.3.2.tgz",
+      "integrity": "sha512-LFkt7ELYXQLgbgHpjl68j6JD5ejUwma8zoPn2gqSBbY+6pK/phjvV1Wkh76muF46VvNulgXF0+qLIDdCsfrDaA==",
+      "requires": {}
+    },
+    "@pixi/mesh-extras": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.3.2.tgz",
+      "integrity": "sha512-s/tg9TsTZZxLEdCDKWnBChDGkc041HCTP7ykJv4fEROzb9B0lskULYyvv+/YNNKa2Ugb9WnkMknpOdOXCpjyyg==",
+      "requires": {}
+    },
+    "@pixi/mixin-cache-as-bitmap": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.3.2.tgz",
+      "integrity": "sha512-bZRlyUN5+9kCUjn67V0IFtYIrbmx9Vs4sMOmXyrX3Q4B4gPLE46IzZz3v0IVaTjp32udlQztfJalIaWbuqgb3A==",
+      "requires": {}
+    },
+    "@pixi/mixin-get-child-by-name": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.3.2.tgz",
+      "integrity": "sha512-mbUi3WxXrkViH7qOgjk4fu2BN36NwNb7u+Fy1J5dS8Bntj57ZVKmEV9PbUy0zYjXE8rVmeAvSu/2kbn5n9UutQ==",
+      "requires": {}
+    },
+    "@pixi/mixin-get-global-position": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.3.2.tgz",
+      "integrity": "sha512-1nhWbBgmw6rK7yQJxzeI9yjKYYEkM5i3pee8qVu4YWo3b1xWVQA7osQG7aGM/4qywDkXaA1ZvciA5hfg6f4Q5Q==",
+      "requires": {}
+    },
+    "@pixi/particle-container": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.3.2.tgz",
+      "integrity": "sha512-JYc4j4z97KmxyLp+1Lg0SNi8hy6RxcBBNQGk+CSLNXeDWxx3hykT5gj/ORX1eXyzHh1ZCG1XzeVS9Yr8QhlFHA==",
+      "requires": {}
+    },
+    "@pixi/prepare": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.3.2.tgz",
+      "integrity": "sha512-aLPAXSYLUhMwxzJtn9m0TSZe+dQlZCt09QNBqYbSi8LZId54QMDyvfBb4zBOJZrD2xAZgYL5RIJuKHwZtFX6lQ==",
+      "requires": {}
     },
     "@pixi/runner": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.3.2.tgz",
-      "integrity": "sha512-maKotoKJCQiQGBJwfM+iYdQKjrPN/Tn9+72F4WIf706zp/5vKoxW688Rsktg5BX4Mcn7ZkZvcJYTxj2Mv87lFA==",
-      "peer": true
+      "integrity": "sha512-maKotoKJCQiQGBJwfM+iYdQKjrPN/Tn9+72F4WIf706zp/5vKoxW688Rsktg5BX4Mcn7ZkZvcJYTxj2Mv87lFA=="
     },
     "@pixi/settings": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.3.2.tgz",
       "integrity": "sha512-vtxzuARDTbFe0fRYSqB53B+mPpX7v+QjjnCUmVMVvZiWr3QcngMWVml6c6dQDln7IakWoKZRrNG4FpggvDgLVg==",
-      "peer": true,
       "requires": {
         "@pixi/constants": "7.3.2",
         "@types/css-font-loading-module": "^0.0.7",
         "ismobilejs": "^1.1.0"
       }
     },
+    "@pixi/sprite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.3.2.tgz",
+      "integrity": "sha512-IpWTKXExJNXVcY7ITopJ+JW48DahdbCo/81D2IYzBImq3jyiJM2Km5EoJgvAM5ZQ3Ev3KPPIBzYLD+HoPWcxdw==",
+      "requires": {}
+    },
+    "@pixi/sprite-animated": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.3.2.tgz",
+      "integrity": "sha512-j9pyUe4cefxE9wecNfbWQyL5fBQKvCGYaOA0DE1X46ukBHrIuhA8u3jg2X3N3r4IcbVvxpWFYDrDsWXWeiBmSw==",
+      "requires": {}
+    },
+    "@pixi/sprite-tiling": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.3.2.tgz",
+      "integrity": "sha512-tWVVb/rMIx5AczfUrVxa0dZaIufP5C0IOL7IGfFUDQqDu5JSAUC0mwLe4F12jAXBVsqYhCGYx5bIHbPiI5vcSQ==",
+      "requires": {}
+    },
+    "@pixi/spritesheet": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.3.2.tgz",
+      "integrity": "sha512-UkwqrPYDqrEdK5ub9qn/9VBvt5caA8ffV5iYR6ssCvrpaQovBKmS+b5pr/BYf8xNTExDpR3OmPIo8iDEYWWLuw==",
+      "requires": {}
+    },
+    "@pixi/text": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.3.2.tgz",
+      "integrity": "sha512-LdtNj+K5tPB/0UcDcO52M/C7xhwFTGFhtdF42fPhRuJawM23M3zm1Y8PapXv+mury+IxCHT1w30YlAi0qTVpKQ==",
+      "requires": {}
+    },
+    "@pixi/text-bitmap": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.3.2.tgz",
+      "integrity": "sha512-p8KLgtZSPowWU/Zj+GVtfsUT8uGYo4TtKKYbLoWuxkRA5Pc1+4C9/rV/EOSFfoZIdW5C+iFg5VxRgBllUQf+aA==",
+      "requires": {}
+    },
+    "@pixi/text-html": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.3.2.tgz",
+      "integrity": "sha512-IYhBWEPOvqUtlHkS5/c1Hseuricj5jrrGd21ivcvHmcnK/x2m+CRGvvzeBp1mqoYBnDbQVrD2wSXSe4Dv9tEJA==",
+      "requires": {}
+    },
     "@pixi/ticker": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.3.2.tgz",
       "integrity": "sha512-5kIPhBeXwDJohCzKzJJ6T7f1oAGbHAgeiwOjlTO+9lNXUX8ZPj0407V3syuF+64kFqJzIBCznBRpI+fmT4c9SA==",
-      "peer": true,
       "requires": {
         "@pixi/extensions": "7.3.2",
         "@pixi/settings": "7.3.2",
@@ -7882,7 +7932,6 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.3.2.tgz",
       "integrity": "sha512-KhNvj9YcY7Zi2dTKZgDpx8C6OxKKR541vwtG6JgdBZZYDeMBOIghN2Vi5zn4diW5BhDfHBmdSJ1wZXEtE2MDwg==",
-      "peer": true,
       "requires": {
         "@pixi/color": "7.3.2",
         "@pixi/constants": "7.3.2",
@@ -8192,8 +8241,7 @@
     "@types/css-font-loading-module": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
-      "peer": true
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="
     },
     "@types/d3": {
       "version": "7.4.3",
@@ -11387,300 +11435,45 @@
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="
     },
     "pixi-viewport": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-5.0.2.tgz",
-      "integrity": "sha512-U77KnCTl81xEgxEQRFEuI7MYVySWwCVkA41EnM8KiOYwgVOwdBUa7318O+u61IOnTwnoYLzaihy/kpoONKU13Q=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-5.0.1.tgz",
+      "integrity": "sha512-fIILU9xztqGnhGF5SYfjn1Rir/7asWkJ8zSUay2hwzPrdGTWFtB4yiIlZDeFaLf7KHA04RRb2kI01Sy1kNksAw=="
     },
     "pixi.js": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.3.3.tgz",
-      "integrity": "sha512-EuAyWZBL5lKViCgYkB6dbwkiI/MNht8O8F8956up9vwGEGf659QRHxfVQoRj8zdNGOBbe51XAxQMfLaW/l0Ekg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.3.2.tgz",
+      "integrity": "sha512-GJickUrT3UcBInGT1CU6cv2oktCdocE5QM74CD3t+weiJPPWIzleNlp7zrBR5QIDdU6bEO8CUgUXH2Y9QvlCMw==",
       "requires": {
-        "@pixi/accessibility": "7.3.3",
-        "@pixi/app": "7.3.3",
-        "@pixi/assets": "7.3.3",
-        "@pixi/compressed-textures": "7.3.3",
-        "@pixi/core": "7.3.3",
-        "@pixi/display": "7.3.3",
-        "@pixi/events": "7.3.3",
-        "@pixi/extensions": "7.3.3",
-        "@pixi/extract": "7.3.3",
-        "@pixi/filter-alpha": "7.3.3",
-        "@pixi/filter-blur": "7.3.3",
-        "@pixi/filter-color-matrix": "7.3.3",
-        "@pixi/filter-displacement": "7.3.3",
-        "@pixi/filter-fxaa": "7.3.3",
-        "@pixi/filter-noise": "7.3.3",
-        "@pixi/graphics": "7.3.3",
-        "@pixi/mesh": "7.3.3",
-        "@pixi/mesh-extras": "7.3.3",
-        "@pixi/mixin-cache-as-bitmap": "7.3.3",
-        "@pixi/mixin-get-child-by-name": "7.3.3",
-        "@pixi/mixin-get-global-position": "7.3.3",
-        "@pixi/particle-container": "7.3.3",
-        "@pixi/prepare": "7.3.3",
-        "@pixi/sprite": "7.3.3",
-        "@pixi/sprite-animated": "7.3.3",
-        "@pixi/sprite-tiling": "7.3.3",
-        "@pixi/spritesheet": "7.3.3",
-        "@pixi/text": "7.3.3",
-        "@pixi/text-bitmap": "7.3.3",
-        "@pixi/text-html": "7.3.3"
-      },
-      "dependencies": {
-        "@pixi/accessibility": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.3.3.tgz",
-          "integrity": "sha512-cHiIEP54RNqvPKmi45HvvnTbiWU+/lzdTY0zK7OXx3TmcEQRn2A7GZ1I+uxx476NeXGJtGSvv3copyxFjPB6Ew==",
-          "requires": {}
-        },
-        "@pixi/app": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.3.3.tgz",
-          "integrity": "sha512-MS5r/yU0CrWMPXXrgKAzgC2KC35Och8fT9z6J1XUCs7yHhdO8768rnSePJuzhj9Yaclv7PUpNQzh8rG9o/MzkQ==",
-          "requires": {}
-        },
-        "@pixi/assets": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.3.3.tgz",
-          "integrity": "sha512-KcLXVehdJ2kc2bSnTfatLPLL6sLD7dwU+EZ5bWQ/PZDSsfML3kLFvq84VXd4k8LKNX4RCvfy4yeeIUW1o5tnMg==",
-          "requires": {
-            "@types/css-font-loading-module": "^0.0.12"
-          }
-        },
-        "@pixi/color": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.3.3.tgz",
-          "integrity": "sha512-IiiFhNIqXt7yULe0Wkq5Hn38ymDoEen/6EvV2y2AQIOu6TyuET5PGswAdMfG7ZjfwBaCudK6yQEUjWaXbgRUmw==",
-          "requires": {
-            "@pixi/colord": "^2.9.6"
-          }
-        },
-        "@pixi/compressed-textures": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.3.3.tgz",
-          "integrity": "sha512-4h1NKePF5blN7qux29yEnKiGdk4vZif59XtLviW7Y3r9MKgKSoizDl0RqU4SKo4eC1P0jpt1qOjiG4TE+AjXGQ==",
-          "requires": {}
-        },
-        "@pixi/constants": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.3.3.tgz",
-          "integrity": "sha512-ww1JdekmKBUqHyPq8A5L+86FkzpS4KidlBm9wkX1fcd+6QQzq/vbx1JOz6m3CmH5LnlmDZ+zysLezvpZlBcwwA=="
-        },
-        "@pixi/core": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.3.3.tgz",
-          "integrity": "sha512-064tuK6NoGIl/2Wf4EUlaLLlnRMZuDdLqnISsj2/A70towg2QUWgHhwZsCB4NvAssidWu/sIT+vk5IKDmh1LKA==",
-          "requires": {
-            "@pixi/color": "7.3.3",
-            "@pixi/constants": "7.3.3",
-            "@pixi/extensions": "7.3.3",
-            "@pixi/math": "7.3.3",
-            "@pixi/runner": "7.3.3",
-            "@pixi/settings": "7.3.3",
-            "@pixi/ticker": "7.3.3",
-            "@pixi/utils": "7.3.3",
-            "@types/offscreencanvas": "^2019.6.4"
-          }
-        },
-        "@pixi/display": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.3.3.tgz",
-          "integrity": "sha512-iULZ2E6Z4vhI0FypXpUbtA+CODnj/CuTt2pi9gsw00ILI12eEx76cAiazvhxnCNqcfmj1RRK2P6s9Vzr5WmEIg==",
-          "requires": {}
-        },
-        "@pixi/events": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.3.3.tgz",
-          "integrity": "sha512-1oDfdFtKsy0Z9ew09MrSYGIIeGnBXr/c7866A32Od3KXql0dhd7UpFFpaFKLCXydDHRgFkjOP7t0/Pp1luTvfg==",
-          "requires": {}
-        },
-        "@pixi/extensions": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.3.3.tgz",
-          "integrity": "sha512-Of44Wde0ZHYCuMoDLFl/8SOSPV2NiDBUB6QKBvYvNdhVslbO3pxrn9oQH9Fmsd8iGcGJ/YtyI5H2T/ky4Bo6AQ=="
-        },
-        "@pixi/extract": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.3.3.tgz",
-          "integrity": "sha512-quD61mNtgq3w2USIPUBOuxD9kVWIPoh8offqJugT4ZZS2XlSnh2FvLjCEC66jVmMM0tmk6HGAfc5xRFNlyw8PQ==",
-          "requires": {}
-        },
-        "@pixi/filter-alpha": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.3.3.tgz",
-          "integrity": "sha512-StLLxEkCyghK3dhzLZD9jMu4lZ/ir4Bah2XXXWGhwE+XCO+//rnXreZ8v74R52WbaLUNDHzwlbq7/+BABwMu5w==",
-          "requires": {}
-        },
-        "@pixi/filter-blur": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.3.3.tgz",
-          "integrity": "sha512-AZzMbcFoL+uHxiVM2nQrQM0MQdLdd5mw7Fd4F60ROB96tmMK/M5W/FTqgdqXUQYld6wCFZKtJMulonVaPKLXDA==",
-          "requires": {}
-        },
-        "@pixi/filter-color-matrix": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.3.3.tgz",
-          "integrity": "sha512-Ot9lQ24lff4DPok0qy+c3IekfEuGf0Y1mx/dB3iLceys2hJHF5wK8rrhKrA1vc5IgrirbZpmjK8it9cVFzEW2g==",
-          "requires": {}
-        },
-        "@pixi/filter-displacement": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.3.3.tgz",
-          "integrity": "sha512-fBnZTUmt6wwazdk/ZDW3HJEkf9s5b8uDuOwHvUAPWTJ6oYqwAjFXnrTlhEwB/Fp+0v6hUVVlHWEYk07HVgjEIg==",
-          "requires": {}
-        },
-        "@pixi/filter-fxaa": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.3.3.tgz",
-          "integrity": "sha512-xq5xcpu68axMrGsVOcpxqebLAa+B4yBSLQlI2rsn7s8YtWY+pC20lsaNnKDlrv9hwJ1Ah7BtBZy0EVVaeFNYqA==",
-          "requires": {}
-        },
-        "@pixi/filter-noise": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.3.3.tgz",
-          "integrity": "sha512-Hwwk1xLvA+0wTqJtKTnIGzyZmLubm5ylgqsMRHQqujDtVSIqE2SY1iVUcGA5vv31C7rFFkxGT4yhtfnYBNCvKQ==",
-          "requires": {}
-        },
-        "@pixi/graphics": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.3.3.tgz",
-          "integrity": "sha512-czX/SEQTSCI3kkH5DFAcchPaPYOAF7cz1P5K2hVvClE/bbbIWN0H2sBIF6pIY1ENkZ0aguQs36yDeXUDWXyoiQ==",
-          "requires": {}
-        },
-        "@pixi/math": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.3.3.tgz",
-          "integrity": "sha512-kaHN6iusINPS0wIbrhP82za+B2qNDWHPHip/QtmpQTp81ibOIfHlDMOlsnE6rSdelTFNhrNWoTWU8IvXUbvy8g=="
-        },
-        "@pixi/mesh": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.3.3.tgz",
-          "integrity": "sha512-8G3FO44wLDimNlCqXBKF+zQ3nBqJ4kMBbIjGxRaRkJmahcMYkY2zJpYsYh1YqKQztL9UmcP5V170VEIcPsmaJw==",
-          "requires": {}
-        },
-        "@pixi/mesh-extras": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.3.3.tgz",
-          "integrity": "sha512-2TW1n97PpSZIZomfoEcKezGeGLPyd82ng2u8SXQoy9keCmB2yK361/RO88jvWbY4qpnJn/89LiLyYEBiJtSmWg==",
-          "requires": {}
-        },
-        "@pixi/mixin-cache-as-bitmap": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.3.3.tgz",
-          "integrity": "sha512-Vv/H24CADY5w2DZaTYhXsfr8wAyKsg6gYn0DLgWDnAI3PWkRcB0fVDfowlHAEzltfxyH4tp9LVc2jtbEIKfSlQ==",
-          "requires": {}
-        },
-        "@pixi/mixin-get-child-by-name": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.3.3.tgz",
-          "integrity": "sha512-75vlViVaynPyIYQIaoU08k1iP+8s9ct2YEnW91vyiHGxxE7BBimiYomWkAUYXtSnaSFoDkNPOh7iI91Icmkf+w==",
-          "requires": {}
-        },
-        "@pixi/mixin-get-global-position": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.3.3.tgz",
-          "integrity": "sha512-ZEScRlx/KSr0z40+xqF9jl9N8j0aFZCNwSluoMLuFecvn4kpaCQx8i4F8j+GkkdrnCfanSYE9ySADlUCsKmzHA==",
-          "requires": {}
-        },
-        "@pixi/particle-container": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.3.3.tgz",
-          "integrity": "sha512-OxigacwSbPjVogahmBYUiYMIH+NhNa+jvGAk5OYEF431gcVmjtravPbk7mmFdGKmOMICztSyVX8kOyhXxCv63A==",
-          "requires": {}
-        },
-        "@pixi/prepare": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.3.3.tgz",
-          "integrity": "sha512-2SdTyHJSDZeaEMuxXqOX01FUDhIjfWUmVCufLXxzjd8gZ52RWBpohl2gDRszPJMyPox142xzUiCnb4RuNXGHDw==",
-          "requires": {}
-        },
-        "@pixi/runner": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.3.3.tgz",
-          "integrity": "sha512-LUObHyxM3tK504ChbioYySZhFhyNs779uA71fuWSFV04Ry0WNlbqVvwTbKGkyR6er6blfxdqk7d51WmuQtfLCg=="
-        },
-        "@pixi/settings": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.3.3.tgz",
-          "integrity": "sha512-a1OePduDPOfnrCm1U1RL7JhuEAncA5/jNwF51urclXU6HNTHiJT41/S6KELPoV8NbLyJCKtnKwzbbPkzKwc0Yg==",
-          "requires": {
-            "@pixi/constants": "7.3.3",
-            "@types/css-font-loading-module": "^0.0.12",
-            "ismobilejs": "^1.1.0"
-          }
-        },
-        "@pixi/sprite": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.3.3.tgz",
-          "integrity": "sha512-P/RxnvNV0PiuyaT9HA8F1aX9krp1BgjllBQcn6KHVxyAP8tJE0TD9pfHOU1+xRuoX37swXRQiDFTF6YvWzozUQ==",
-          "requires": {}
-        },
-        "@pixi/sprite-animated": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.3.3.tgz",
-          "integrity": "sha512-BYvehHk3PlNln9tRfZ/zGp2MzVwRjggFe+s4NCQd1EU/NPQewqJGCAiQFB4Gc3hFK2Y8wkW7SpGAzuk/E2WTxg==",
-          "requires": {}
-        },
-        "@pixi/sprite-tiling": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.3.3.tgz",
-          "integrity": "sha512-T4ms0TcfKq7JNRaUBaQyZsaxWziPh2EY10vFQEG17J3uyCrjQmN4dDS9AMoaltL1K3vh+CTSUnWO8S8mE1dn4Q==",
-          "requires": {}
-        },
-        "@pixi/spritesheet": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.3.3.tgz",
-          "integrity": "sha512-aAebizGNiKijWmJ39bnAb8FbuXbxRINuWZ2xt7ANzJQxhbo7dX+qlF4pz91yj3gHQaulzJM2oKz4a5q6cHa7dw==",
-          "requires": {}
-        },
-        "@pixi/text": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.3.3.tgz",
-          "integrity": "sha512-s9BLmiURYeJppPYB040jrGbtbsWM9PcXSRtr40xrbR0a+HPlxDEWCaHka9DiUFr/lIuOpA0y/YjmZskq5o5R7g==",
-          "requires": {}
-        },
-        "@pixi/text-bitmap": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.3.3.tgz",
-          "integrity": "sha512-2IOBoSHtb2e1aoxB/pfJPFW34XeY8HpDtGJKn3F9IUYpBo6nnnZ6DuJNZyFG2r/hiytjVvulqI66CzOH/eJJ4A==",
-          "requires": {}
-        },
-        "@pixi/text-html": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.3.3.tgz",
-          "integrity": "sha512-z8vsgsqVJuFEVX07wh0IYAwQ5DBiel8Lhxo2Ly8594O0mIdQ1IPvtAPv+WRyG35WT0i26J7GL2BZxURouDP2WA==",
-          "requires": {}
-        },
-        "@pixi/ticker": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.3.3.tgz",
-          "integrity": "sha512-AxeMKP9vTcla+yYXCABc0uKUODjIsJRXk3DCHVpoPeeqRYPaKH291RtDw92QFw7FFgGBbRgsptBjF9Q+uO5hDA==",
-          "requires": {
-            "@pixi/extensions": "7.3.3",
-            "@pixi/settings": "7.3.3",
-            "@pixi/utils": "7.3.3"
-          }
-        },
-        "@pixi/utils": {
-          "version": "7.3.3",
-          "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.3.3.tgz",
-          "integrity": "sha512-rgWD0YV6oDKOVuQJ9ra6g3VdoN8usC6Kj/t3Ba1t9P+k9qUKIM0gCr9/bxFf7CJ/EUS8A2WTVfEmJVN2TwZfxg==",
-          "requires": {
-            "@pixi/color": "7.3.3",
-            "@pixi/constants": "7.3.3",
-            "@pixi/settings": "7.3.3",
-            "@types/earcut": "^2.1.0",
-            "earcut": "^2.2.4",
-            "eventemitter3": "^4.0.0",
-            "url": "^0.11.0"
-          }
-        },
-        "@types/css-font-loading-module": {
-          "version": "0.0.12",
-          "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
-          "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA=="
-        }
+        "@pixi/accessibility": "7.3.2",
+        "@pixi/app": "7.3.2",
+        "@pixi/assets": "7.3.2",
+        "@pixi/compressed-textures": "7.3.2",
+        "@pixi/core": "7.3.2",
+        "@pixi/display": "7.3.2",
+        "@pixi/events": "7.3.2",
+        "@pixi/extensions": "7.3.2",
+        "@pixi/extract": "7.3.2",
+        "@pixi/filter-alpha": "7.3.2",
+        "@pixi/filter-blur": "7.3.2",
+        "@pixi/filter-color-matrix": "7.3.2",
+        "@pixi/filter-displacement": "7.3.2",
+        "@pixi/filter-fxaa": "7.3.2",
+        "@pixi/filter-noise": "7.3.2",
+        "@pixi/graphics": "7.3.2",
+        "@pixi/mesh": "7.3.2",
+        "@pixi/mesh-extras": "7.3.2",
+        "@pixi/mixin-cache-as-bitmap": "7.3.2",
+        "@pixi/mixin-get-child-by-name": "7.3.2",
+        "@pixi/mixin-get-global-position": "7.3.2",
+        "@pixi/particle-container": "7.3.2",
+        "@pixi/prepare": "7.3.2",
+        "@pixi/sprite": "7.3.2",
+        "@pixi/sprite-animated": "7.3.2",
+        "@pixi/sprite-tiling": "7.3.2",
+        "@pixi/spritesheet": "7.3.2",
+        "@pixi/text": "7.3.2",
+        "@pixi/text-bitmap": "7.3.2",
+        "@pixi/text-html": "7.3.2"
       }
     },
     "plimit-lit": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "gsap": "^3.12.2",
     "lodash.isequal": "4.5.0",
     "lodash.merge": "4.6.2",
-    "pixi-viewport": "5.0.2",
-    "pixi.js": "7.3.3"
+    "pixi-viewport": "5.0.1",
+    "pixi.js": "7.3.2"
   }
 }


### PR DESCRIPTION
A couple dependabot PR's got merged to bump these packages, but since pixi-viewport doesn't quite stay in lock step, this can cause problems. We'll likely want to manage these package updates manually, unfortunately.

In this case, `pixi-viewport` was bumped to 5.0.2, but that [doesn't seem to exist](https://github.com/davidfig/pixi-viewport/releases/tag/5.0.1) (maybe it was deleted?). Bumping Pixi.js creates type updates that pixi-viewport isn't ready for and leads typescript to believe that the viewport can't be added as a child of Pixi. I think there may also still be deprecated uses of `interactive` in pixi-viewport that aren't supported in Pixi v7.4.0.