### PR TITLE
add artifacts fetcher

### DIFF
--- a/demo/data/artifacts.json
+++ b/demo/data/artifacts.json
@@ -1,0 +1,50 @@
+[
+  {
+      "id": "d86b507d-c784-4bf2-b12c-ff6953026257",
+      "key": "variable-data-link",
+      "flowRunId": "root-1234",
+      "taskRunId": "b00e48b1-be37-4d22-a3e9-e6c69847f3da",
+      "created": "2024-01-30T16:29:31.776Z",
+      "updated": "2024-01-30T16:29:31.776Z",
+      "type": "markdown",
+      "description": "## Highly variable data",
+      "data": "[Highly variable data](https://nyc3.digitaloceanspaces.com/my-bucket-name/highly_variable_data_.csv)",
+      "metadata": null
+  },
+  {
+      "id": "cae8b622-6742-4615-a02f-700323eaeb41",
+      "key": "personalized-reachout",
+      "flowRunId": "root-1234",
+      "taskRunId": "9c5a12e5-61e3-42b8-af3e-b99e37f4ff5e",
+      "created": "2024-01-30T16:29:32.606Z",
+      "updated": "2024-01-30T16:29:32.606Z",
+      "type": "table",
+      "description": "# Marvin, please reach out to these customers today!",
+      "data": "[{\"customer_id\": \"12345\", \"name\": \"John Smith\", \"churn_probability\": 0.85}, {\"customer_id\": \"56789\", \"name\": \"Jane Jones\", \"churn_probability\": 0.65}]",
+      "metadata": null
+  },
+  {
+      "id": "c922b8ce-78e4-459c-8549-b5f6adf5342d",
+      "key": "gtm-markdown-report",
+      "flowRunId": "root-1234",
+      "taskRunId": "68ba2fce-caac-4b07-9f1c-4cb25ff6a3ec",
+      "created": "2024-01-30T16:29:31.027Z",
+      "updated": "2024-01-30T16:29:31.027Z",
+      "type": "markdown",
+      "description": "Quarterly Sales Report",
+      "data": "# Sales Report\n\n## Summary\n\nIn the past quarter, our company saw a significant increase in sales, with a total revenue of $1,000,000. This represents a 20% increase over the same period last year.\n\n## Sales by Region\n\n| Region        | Revenue |\n|:--------------|-------:|\n| North America | $500,000 |\n| Europe        | $250,000 |\n| Asia          | $150,000 |\n| South America | $75,000 |\n| Africa        | $25,000 |\n\n## Top Products\n\n1. Product A - $300,000 in revenue\n2. Product B - $200,000 in revenue\n3. Product C - $150,000 in revenue\n\n## Conclusion\n\nOverall, these results are very encouraging and demonstrate the success of our sales team in increasing revenue across all regions. However, we still have room for improvement and should focus on further increasing sales in the coming quarter.\n",
+      "metadata": null
+  },
+  {
+      "id": "ae8aab85-b3bd-44b7-90d0-8afc95bf1ba3",
+      "key": "variable-data-link",
+      "flowRunId": "root-1234",
+      "taskRunId": "",
+      "created": "2024-01-30T16:29:32.215Z",
+      "updated": "2024-01-30T16:29:32.215Z",
+      "type": "markdown",
+      "description": "# Low prediction accuracy data",
+      "data": "[https://nyc3.digitaloceanspaces.com/my-bucket-name/low_pred_data_.csv](https://nyc3.digitaloceanspaces.com/my-bucket-name/low_pred_data_.csv)",
+      "metadata": null
+  }
+]

--- a/demo/sections/components/RunGraphDemo.vue
+++ b/demo/sections/components/RunGraphDemo.vue
@@ -10,8 +10,9 @@
   import { parseISO, isValid } from 'date-fns'
   import { computed, ref } from 'vue'
   import RunGraph from '@/components/RunGraph.vue'
+  import artifactJson from '@/demo/data/artifacts.json'
   import json from '@/demo/data/graph-small.json'
-  import { RunGraphConfig, RunGraphData } from '@/models'
+  import { Artifact, RunGraphConfig, RunGraphData } from '@/models'
   import { StateType } from '@/models/states'
   import { ViewportDateRange } from '@/models/viewport'
 
@@ -35,6 +36,7 @@
   }
 
   const data: RunGraphData = JSON.parse(JSON.stringify(json), reviver)
+  const artifacts: Artifact[] = JSON.parse(JSON.stringify(artifactJson), reviver)
   const visibleDateRange = ref<ViewportDateRange>()
   const selected = ref()
 
@@ -59,7 +61,8 @@
 
   const config = computed<RunGraphConfig>(() => ({
     runId: 'foo',
-    fetch: () => data,
+    fetchGraph: () => data,
+    fetchArtifacts: () => artifacts,
     styles: {
       colorMode: colorThemeValue.value,
       textDefault: getColorToken('--p-color-text-default'),

--- a/src/factories/data.ts
+++ b/src/factories/data.ts
@@ -1,8 +1,13 @@
 import { millisecondsInSecond } from 'date-fns/constants'
-import { RunGraphData } from '@/models/RunGraph'
+import { RunGraphData, Artifact } from '@/models'
 import { waitForConfig } from '@/objects/config'
 
-type DataCallback = (data: RunGraphData) => void
+type DataFactoryBundle = {
+  data: RunGraphData,
+  artifacts: Artifact[],
+}
+
+type DataCallback = (dataBundle: DataFactoryBundle) => void
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function dataFactory(runId: string, callback: DataCallback) {
@@ -13,9 +18,16 @@ export async function dataFactory(runId: string, callback: DataCallback) {
 
   async function start(): Promise<void> {
     try {
-      data = await config.fetch(runId)
+      const [graphData, artifacts] = await Promise.all([
+        config.fetchGraph(runId),
+        config.fetchArtifacts(runId),
+      ])
+      data = graphData
 
-      callback(data)
+      callback({
+        data,
+        artifacts,
+      })
     } catch (error) {
       console.error(error)
     }

--- a/src/factories/nodeFlowRun.ts
+++ b/src/factories/nodeFlowRun.ts
@@ -21,7 +21,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   const { element: nodesContainer, render: renderNodes, getSize: getNodesSize, stopWorker: stopNodesWorker } = await nodesContainerFactory()
   const { element: arrowButton, render: renderArrowButtonContainer } = await nodeArrowButtonFactory()
   const { element: border, render: renderBorderContainer } = await borderFactory()
-  const { start: startData, stop: stopData } = await dataFactory(node.id, data => {
+  const { start: startData, stop: stopData } = await dataFactory(node.id, ({ data }) => {
     renderNodes(data)
   })
 

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -1,4 +1,5 @@
 import { ColorSource } from 'pixi.js'
+import { Artifact } from '@/models/artifact'
 import { NodeSelection } from '@/models/selection'
 import { StateType } from '@/models/states'
 import { ViewportDateRange } from '@/models/viewport'
@@ -43,6 +44,8 @@ export function isRunGraphNodeType(value: unknown): value is RunGraphNodeKind {
 
 export type RunGraphFetch = (runId: string) => RunGraphData | Promise<RunGraphData>
 
+export type ArtifactsFetch = (runId: string) => Artifact[] | Promise<Artifact[]>
+
 export type RunGraphNodeStyles = {
   background?: ColorSource,
 }
@@ -78,7 +81,8 @@ export type RunGraphStyles = {
 
 export type RunGraphConfig = {
   runId: string,
-  fetch: RunGraphFetch,
+  fetchGraph: RunGraphFetch,
+  fetchArtifacts: ArtifactsFetch,
   animationDuration?: number,
   styles?: RunGraphStyles,
   disableAnimationsThreshold?: number,

--- a/src/models/artifact.ts
+++ b/src/models/artifact.ts
@@ -1,0 +1,16 @@
+export const artifactTypes = [
+  'result',
+  'markdown',
+  'table',
+  'unknown',
+] as const
+
+export type ArtifactType = typeof artifactTypes[number]
+
+export type Artifact = {
+  id: string,
+  flowRunId: string | null,
+  taskRunId: string | null,
+  created: Date,
+  type: ArtifactType,
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,3 +1,4 @@
+export * from './artifact'
 export * from './RunGraph'
 export * from './viewport'
 export * from './selection'

--- a/src/objects/config.ts
+++ b/src/objects/config.ts
@@ -6,7 +6,7 @@ import { waitForScope } from '@/objects/scope'
 
 let config: RequiredGraphConfig | null = null
 
-const defaults: Omit<RequiredGraphConfig, 'runId' | 'fetch'> = {
+const defaults: Omit<RequiredGraphConfig, 'runId' | 'fetchGraph' | 'fetchArtifacts'> = {
   animationDuration: 500,
   disableAnimationsThreshold: 500,
   disableEdgesThreshold: 500,

--- a/src/objects/nodes.ts
+++ b/src/objects/nodes.ts
@@ -20,7 +20,7 @@ export async function startNodes(): Promise<void> {
 
   element.alpha = 0
 
-  const response = await dataFactory(config.runId, async data => {
+  const response = await dataFactory(config.runId, async ({ data }) => {
     const event: EventKey = runGraphData ? 'runDataUpdated' : 'runDataCreated'
 
     runGraphData = data


### PR DESCRIPTION
This PR extends the config to include additional fetchers, in this case one for "artifacts" has been added. Keeping the fetchers separate, rather than combining the data or updating the run graph API, keeps things flexible as additional layers are added in the Flow Run Graph layers raft. The `dataFactory` is still solely responsible for retrieving all data, so that additional layers are accessible to nodes right away.