### PR TITLE
add ability to disable artifacts

### DIFF
--- a/demo/sections/components/RunGraphDemo.vue
+++ b/demo/sections/components/RunGraphDemo.vue
@@ -5,7 +5,7 @@
     <p-drawer v-model:open="artifactDrawerOpen" placement="right" class="p-background p-4">
       <span class="text-sm text-subdued">Inspecting</span>
       <h2 class="mb-2">
-        {{ selected?.id }}
+        {{ selected && 'id' in selected ? selected.id : selected?.ids.join(', ') }}
       </h2>
       <span class="text-sm text-subdued">Stuff</span>
       <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Eaque recusandae ad, nam hic ipsam est dolor cumque optio nostrum quaerat?</p>

--- a/demo/sections/components/RunGraphDemo.vue
+++ b/demo/sections/components/RunGraphDemo.vue
@@ -1,6 +1,12 @@
 <template>
   <p-layout-default class="run-graph-demo">
-    <RunGraph v-model:viewport="visibleDateRange" v-model:selected="selected" :config="config" class="run-graph-demo__graph p-background" />
+    <RunGraph
+      v-model:viewport="visibleDateRange"
+      v-model:selected="selected"
+      has-artifacts
+      :config="config"
+      class="run-graph-demo__graph p-background"
+    />
     {{ visibleDateRange }} {{ selected }}
     <p-drawer v-model:open="artifactDrawerOpen" placement="right" class="p-background p-4">
       <span class="text-sm text-subdued">Inspecting</span>

--- a/src/components/RunGraph.vue
+++ b/src/components/RunGraph.vue
@@ -4,7 +4,7 @@
     <div class="run-graph__actions">
       <p-button title="Recenter graph (c)" icon="Target" flat @click="center" />
       <p-button title="Toggle fullscreen (f)" icon="ArrowsPointingOutIcon" flat @click="toggleFullscreen" />
-      <RunGraphSettings />
+      <RunGraphSettings :has-artifacts="props.hasArtifacts" />
     </div>
   </div>
 </template>
@@ -26,6 +26,7 @@
   const props = withDefaults(defineProps<RunGraphProps>(), {
     fullscreen: null,
     selected: null,
+    hasArtifacts: false,
   })
 
   const emit = defineEmits<{

--- a/src/components/RunGraphSettings.vue
+++ b/src/components/RunGraphSettings.vue
@@ -35,6 +35,7 @@
       </template>
       <p-divider />
       <p-checkbox v-model="hideEdges" label="Hide dependency arrows" />
+      <!-- <p-checkbox v-model="hideArtifacts" label="Hide artifacts" /> -->
     </p-overflow-menu>
   </p-pop-over>
 </template>
@@ -45,7 +46,7 @@
   import { computed } from 'vue'
   import { DEFAULT_HORIZONTAL_SCALE_MULTIPLIER } from '@/consts'
   import { HorizontalMode, VerticalMode } from '@/models/layout'
-  import { layout, resetHorizontalScaleMultiplier, setDisabledEdges, setHorizontalMode, setHorizontalScaleMultiplier, setVerticalMode } from '@/objects/settings'
+  import { layout, resetHorizontalScaleMultiplier, setDisabledEdges, setDisabledArtifacts, setHorizontalMode, setHorizontalScaleMultiplier, setVerticalMode } from '@/objects/settings'
   import { eventTargetIsInput } from '@/utilities/keyboard'
 
   type Option<T extends string> = {
@@ -94,6 +95,15 @@
     },
     set(value) {
       setDisabledEdges(value)
+    },
+  })
+
+  const hideArtifacts = computed({
+    get() {
+      return layout.disableArtifacts
+    },
+    set(value) {
+      setDisabledArtifacts(value)
     },
   })
 

--- a/src/components/RunGraphSettings.vue
+++ b/src/components/RunGraphSettings.vue
@@ -35,7 +35,9 @@
       </template>
       <p-divider />
       <p-checkbox v-model="hideEdges" label="Hide dependency arrows" />
-      <!-- <p-checkbox v-model="hideArtifacts" label="Hide artifacts" /> -->
+      <template v-if="hasArtifacts">
+        <p-checkbox v-model="hideArtifacts" label="Hide artifacts" />
+      </template>
     </p-overflow-menu>
   </p-pop-over>
 </template>
@@ -48,6 +50,10 @@
   import { HorizontalMode, VerticalMode } from '@/models/layout'
   import { layout, resetHorizontalScaleMultiplier, setDisabledEdges, setDisabledArtifacts, setHorizontalMode, setHorizontalScaleMultiplier, setVerticalMode } from '@/objects/settings'
   import { eventTargetIsInput } from '@/utilities/keyboard'
+
+  defineProps<{
+    hasArtifacts: boolean,
+  }>()
 
   type Option<T extends string> = {
     value: T,

--- a/src/factories/artifactCluster.ts
+++ b/src/factories/artifactCluster.ts
@@ -9,6 +9,7 @@ import { waitForConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
 import { waitForScale } from '@/objects/scale'
 import { isSelected, selectItem } from '@/objects/selection'
+import { waitForSettings } from '@/objects/settings'
 
 export type ArtifactClusterFactory = Awaited<ReturnType<typeof artifactClusterFactory>>
 
@@ -27,6 +28,7 @@ export async function artifactClusterFactory() {
   const application = await waitForApplication()
   const viewport = await waitForViewport()
   const config = await waitForConfig()
+  const settings = await waitForSettings()
   let scale = await waitForScale()
 
   const element = new Container()
@@ -162,7 +164,7 @@ export async function artifactClusterFactory() {
   }
 
   function updatePosition(): void {
-    if (!currentDate) {
+    if (settings.disableArtifacts || !currentDate) {
       return
     }
 

--- a/src/factories/flowRunArtifact.ts
+++ b/src/factories/flowRunArtifact.ts
@@ -7,7 +7,7 @@ import { waitForConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
 import { waitForScale } from '@/objects/scale'
 import { isSelected } from '@/objects/selection'
-import { layout } from '@/objects/settings'
+import { layout, waitForSettings } from '@/objects/settings'
 
 export type FlowRunArtifactFactory = Awaited<ReturnType<typeof flowRunArtifactFactory>>
 
@@ -16,6 +16,7 @@ export async function flowRunArtifactFactory(artifact: Artifact) {
   const application = await waitForApplication()
   const viewport = await waitForViewport()
   const config = await waitForConfig()
+  const settings = await waitForSettings()
   let scale = await waitForScale()
 
   const { element, render: renderArtifact } = await artifactFactory(artifact, { cullAtZoomThreshold: false })
@@ -40,7 +41,7 @@ export async function flowRunArtifactFactory(artifact: Artifact) {
   }
 
   function updatePosition(): void {
-    if (!layout.isTemporal()) {
+    if (settings.disableArtifacts || !layout.isTemporal()) {
       return
     }
 

--- a/src/factories/flowRunArtifact.ts
+++ b/src/factories/flowRunArtifact.ts
@@ -3,8 +3,10 @@ import { DEFAULT_ROOT_ARTIFACT_BOTTOM_OFFSET } from '@/consts'
 import { artifactFactory } from '@/factories/artifact'
 import { Artifact } from '@/models'
 import { waitForApplication, waitForViewport } from '@/objects'
+import { waitForConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
 import { waitForScale } from '@/objects/scale'
+import { isSelected } from '@/objects/selection'
 import { layout } from '@/objects/settings'
 
 export type FlowRunArtifactFactory = Awaited<ReturnType<typeof flowRunArtifactFactory>>
@@ -13,12 +15,23 @@ export type FlowRunArtifactFactory = Awaited<ReturnType<typeof flowRunArtifactFa
 export async function flowRunArtifactFactory(artifact: Artifact) {
   const application = await waitForApplication()
   const viewport = await waitForViewport()
+  const config = await waitForConfig()
   let scale = await waitForScale()
 
   const { element, render: renderArtifact } = await artifactFactory(artifact, { cullAtZoomThreshold: false })
 
+  let isArtifactSelected = false
+
   emitter.on('scaleUpdated', updated => scale = updated)
   emitter.on('viewportMoved', () => updatePosition())
+  emitter.on('itemSelected', () => {
+    const isCurrentlySelected = isSelected(artifact)
+
+    if (isCurrentlySelected !== isArtifactSelected) {
+      isArtifactSelected = isCurrentlySelected
+      render()
+    }
+  })
 
   async function render(): Promise<Container> {
     await renderArtifact()
@@ -31,10 +44,18 @@ export async function flowRunArtifactFactory(artifact: Artifact) {
       return
     }
 
-    const x = scale(artifact.created) * viewport.scale._x + viewport.worldTransform.tx
-    const y = application.screen.height - element.height - DEFAULT_ROOT_ARTIFACT_BOTTOM_OFFSET
+    let selectedOffset = 0
 
-    element.position.set(x - element.width / 2, y)
+    if (isArtifactSelected) {
+      const { selectedBorderOffset, selectedBorderWidth } = config.styles
+      selectedOffset = selectedBorderOffset + selectedBorderWidth * 2
+    }
+
+    const x = scale(artifact.created) * viewport.scale._x + viewport.worldTransform.tx
+    const centeredX = x - (element.width - selectedOffset) / 2
+    const y = application.screen.height - (element.height - selectedOffset) - DEFAULT_ROOT_ARTIFACT_BOTTOM_OFFSET
+
+    element.position.set(centeredX, y)
   }
 
   return {

--- a/src/factories/flowRunArtifacts.ts
+++ b/src/factories/flowRunArtifacts.ts
@@ -15,13 +15,13 @@ export async function flowRunArtifactsFactory() {
   const application = await waitForApplication()
   const viewport = await waitForViewport()
   const config = await waitForConfig()
+  const settings = await waitForSettings()
 
   const artifacts: Map<string, FlowRunArtifactFactory> = new Map()
   const clusterNodes: ArtifactClusterFactory[] = []
 
   let container: Container | null = null
   let internalData: Artifact[] | null = null
-  let isArtifactsDisabled = false
   let availableClusterNodes: ArtifactClusterFactory[] = []
   let visibleItems: (FlowRunArtifactFactory | ArtifactClusterFactory)[] = []
   let nonTemporalAlignmentEngaged = false
@@ -29,15 +29,11 @@ export async function flowRunArtifactsFactory() {
   emitter.on('viewportMoved', () => update())
 
   async function render(newData?: Artifact[]): Promise<void> {
-    const settings = await waitForSettings()
-
-    isArtifactsDisabled = settings.disableArtifacts
-
     if (container) {
-      container.visible = !isArtifactsDisabled
+      container.visible = !settings.disableArtifacts
     }
 
-    if (isArtifactsDisabled) {
+    if (settings.disableArtifacts) {
       return
     }
 
@@ -83,7 +79,7 @@ export async function flowRunArtifactsFactory() {
   }
 
   function update(): void {
-    if (isArtifactsDisabled || !container) {
+    if (!container || settings.disableArtifacts) {
       return
     }
 

--- a/src/factories/flowRunArtifacts.ts
+++ b/src/factories/flowRunArtifacts.ts
@@ -8,7 +8,7 @@ import { BoundsContainer } from '@/models/boundsContainer'
 import { waitForApplication, waitForViewport } from '@/objects'
 import { waitForConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
-import { layout } from '@/objects/settings'
+import { layout, waitForSettings } from '@/objects/settings'
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function flowRunArtifactsFactory() {
@@ -21,6 +21,7 @@ export async function flowRunArtifactsFactory() {
 
   let container: Container | null = null
   let internalData: Artifact[] | null = null
+  let isArtifactsDisabled = false
   let availableClusterNodes: ArtifactClusterFactory[] = []
   let visibleItems: (FlowRunArtifactFactory | ArtifactClusterFactory)[] = []
   let nonTemporalAlignmentEngaged = false
@@ -28,6 +29,18 @@ export async function flowRunArtifactsFactory() {
   emitter.on('viewportMoved', () => update())
 
   async function render(newData?: Artifact[]): Promise<void> {
+    const settings = await waitForSettings()
+
+    isArtifactsDisabled = settings.disableArtifacts
+
+    if (container) {
+      container.visible = !isArtifactsDisabled
+    }
+
+    if (isArtifactsDisabled) {
+      return
+    }
+
     if (newData) {
       internalData = newData
     }
@@ -70,7 +83,7 @@ export async function flowRunArtifactsFactory() {
   }
 
   function update(): void {
-    if (!container) {
+    if (isArtifactsDisabled || !container) {
       return
     }
 

--- a/src/factories/node.ts
+++ b/src/factories/node.ts
@@ -13,7 +13,7 @@ import { waitForConfig } from '@/objects/config'
 import { waitForCull } from '@/objects/culling'
 import { emitter } from '@/objects/events'
 import { isSelected, selectItem } from '@/objects/selection'
-import { layout } from '@/objects/settings'
+import { layout, waitForSettings } from '@/objects/settings'
 
 export type NodeContainerFactory = Awaited<ReturnType<typeof nodeContainerFactory>>
 
@@ -22,6 +22,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
   const config = await waitForConfig()
   const application = await waitForApplication()
   const cull = await waitForCull()
+  const settings = await waitForSettings()
   let artifactsContainer: Container | null = null
   const artifacts: Map<string, ArtifactFactory> = new Map()
   const { animate } = await animationFactory()
@@ -59,6 +60,10 @@ export async function nodeContainerFactory(node: RunGraphNode) {
   async function render(node: RunGraphNode): Promise<BoundsContainer> {
     internalNode = node
 
+    if (artifactsContainer) {
+      artifactsContainer.visible = !settings.disableArtifacts
+    }
+
     const currentCacheKey = getNodeCacheKey(node)
 
     if (currentCacheKey === cacheKey) {
@@ -80,7 +85,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
   }
 
   async function createArtifacts(artifactsData?: Artifact[]): Promise<void> {
-    if (!artifactsData) {
+    if (settings.disableArtifacts || !artifactsData) {
       return
     }
 

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -9,6 +9,7 @@ export type RunGraphProps = {
   viewport?: ViewportDateRange,
   fullscreen?: boolean | null,
   selected?: GraphItemSelection | null,
+  hasArtifacts?: boolean,
 }
 
 export type RunGraphData = {

--- a/src/models/layout.ts
+++ b/src/models/layout.ts
@@ -15,6 +15,7 @@ export type LayoutSettings = {
   disableEdges: boolean,
   disableAnimations: boolean,
   disableGuides: boolean,
+  disableArtifacts: boolean,
   isTemporal: () => boolean,
   isDependency: () => boolean,
   isWaterfall: () => boolean,

--- a/src/models/selection.ts
+++ b/src/models/selection.ts
@@ -1,8 +1,8 @@
 import { RunGraphNode, Artifact } from '@/models'
 
 export type NodeSelection = {
-  id: string,
   kind: RunGraphNode['kind'],
+  id: string,
 }
 
 export type ArtifactSelection = {
@@ -10,6 +10,14 @@ export type ArtifactSelection = {
   id: string,
 }
 
-export type GraphItemSelection = NodeSelection | ArtifactSelection
+export type ArtifactClusterSelection = {
+  kind: 'artifactCluster',
+  ids: string[],
+}
 
-export type SelectableItem = RunGraphNode | Artifact
+export type GraphItemSelection =
+  | NodeSelection
+  | ArtifactSelection
+  | ArtifactClusterSelection
+
+export type SelectableItem = RunGraphNode | Artifact | string[]

--- a/src/objects/flowRunArtifacts.ts
+++ b/src/objects/flowRunArtifacts.ts
@@ -1,12 +1,18 @@
 import { flowRunArtifactsFactory } from '@/factories/flowRunArtifacts'
 import { RunGraphData } from '@/models/RunGraph'
 import { emitter } from '@/objects/events'
+import { waitForRunData } from '@/objects/nodes'
 
 export async function startFlowRunArtifacts(): Promise<void> {
+  const data = await waitForRunData()
   const { render: renderArtifacts } = await flowRunArtifactsFactory()
 
   function render(newData?: RunGraphData): void {
     renderArtifacts(newData?.artifacts)
+  }
+
+  if (data.artifacts) {
+    render(data)
   }
 
   emitter.on('runDataCreated', (data) => render(data))

--- a/src/objects/selection.ts
+++ b/src/objects/selection.ts
@@ -50,7 +50,23 @@ export function selectItem(item: GraphItemSelection | null): void {
 }
 
 export function isSelected(item: GraphItemSelection | SelectableItem | null): boolean {
-  return item?.id === selected?.id
+  if (item === null || selected === null) {
+    return false
+  }
+
+  if (Array.isArray(item) && 'ids' in selected) {
+    return item.length === selected.ids.length && selected.ids.every(id => item.includes(id))
+  }
+
+  if ('ids' in item && 'ids' in selected) {
+    return item.ids.length === selected.ids.length && selected.ids.every(id => item.ids.includes(id))
+  }
+
+  if ('id' in item && 'id' in selected) {
+    return item.id === selected.id
+  }
+
+  return false
 }
 
 export function getSelectedRunGraphNode(): NodeSelection | null {

--- a/src/objects/settings.ts
+++ b/src/objects/settings.ts
@@ -47,6 +47,7 @@ export const layout = reactive<LayoutSettings>({
   disableAnimations: false,
   disableEdges: false,
   disableGuides: false,
+  disableArtifacts: false,
   isTemporal() {
     return this.horizontal === 'temporal'
   },
@@ -163,6 +164,18 @@ export function setDisabledEdges(value: boolean): void {
   const emit = emitFactory()
 
   layout.disableEdges = value
+
+  emit()
+}
+
+export function setDisabledArtifacts(value: boolean): void {
+  if (layout.disableArtifacts === value) {
+    return
+  }
+
+  const emit = emitFactory()
+
+  layout.disableArtifacts = value
 
   emit()
 }


### PR DESCRIPTION
Adds the ability to disable all artifacts. The option is optional, the idea being that we'll only show it if there is an artifacts count. Arguably, there could instead be a `has_artifacts` field on the graph data, open to opinions there.

<img width="1066" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6776415/4dcc4525-e335-4634-89f1-bdb07270365c">
