### PR TITLE
Bugfix: update flowRunArtifact positions on child render

### DIFF
--- a/src/factories/artifact.ts
+++ b/src/factories/artifact.ts
@@ -33,10 +33,8 @@ export async function artifactFactory(artifact: Artifact, { cullAtZoomThreshold 
     }
   })
 
-  async function render(): Promise<Container> {
+  async function render(): Promise<void> {
     await renderArtifactNode({ selected, name: artifact.key, type: artifact.type })
-
-    return element
   }
 
   function getSelected(): boolean {

--- a/src/factories/artifactCluster.ts
+++ b/src/factories/artifactCluster.ts
@@ -33,12 +33,12 @@ export async function artifactClusterFactory() {
     }
   })
 
-  async function render(props?: ArtifactClusterFactoryRenderProps): Promise<string[]> {
+  async function render(props?: ArtifactClusterFactoryRenderProps): Promise<void> {
     if (!props) {
       currentDate = null
       currentIds = []
       element.visible = false
-      return []
+      return
     }
 
     const { ids, date } = props
@@ -47,8 +47,6 @@ export async function artifactClusterFactory() {
 
     await renderArtifactNode({ selected, type: 'unknown', name: ids.length.toString() })
     element.visible = true
-
-    return ids
   }
 
   function getSelected(): boolean {

--- a/src/factories/flowRunArtifacts.ts
+++ b/src/factories/flowRunArtifacts.ts
@@ -5,7 +5,6 @@ import { ArtifactFactory } from '@/factories/artifact'
 import { ArtifactClusterFactory } from '@/factories/artifactCluster'
 import { flowRunArtifactFactory, FlowRunArtifactFactory } from '@/factories/flowRunArtifact'
 import { Artifact } from '@/models'
-import { BoundsContainer } from '@/models/boundsContainer'
 import { waitForApplication, waitForViewport } from '@/objects'
 import { waitForConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
@@ -48,7 +47,7 @@ export async function flowRunArtifactsFactory() {
       createContainer()
     }
 
-    const promises: Promise<BoundsContainer>[] = []
+    const promises: Promise<void>[] = []
 
     for (const artifact of internalData) {
       promises.push(createArtifact(artifact))
@@ -57,7 +56,7 @@ export async function flowRunArtifactsFactory() {
     await Promise.all(promises)
   }
 
-  async function createArtifact(artifact: Artifact): Promise<BoundsContainer> {
+  async function createArtifact(artifact: Artifact): Promise<void> {
     if (artifacts.has(artifact.id)) {
       return artifacts.get(artifact.id)!.render()
     }

--- a/src/factories/node.ts
+++ b/src/factories/node.ts
@@ -93,7 +93,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
       createArtifactsContainer()
     }
 
-    const promises: Promise<BoundsContainer>[] = []
+    const promises: Promise<void>[] = []
 
     for (const artifact of artifactsData) {
       promises.push(createArtifact(artifact))
@@ -104,7 +104,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
     alignArtifacts()
   }
 
-  async function createArtifact(artifact: Artifact): Promise<BoundsContainer> {
+  async function createArtifact(artifact: Artifact): Promise<void> {
     if (artifacts.has(artifact.id)) {
       return artifacts.get(artifact.id)!.render()
     }


### PR DESCRIPTION
Since turning `flowRunArtifact` into essentially a thin wrapper for `artifact` and `artifactCluster` that handles position, I discovered that positions weren't being called when the child render functions were fired, resulting in false positioning.

https://github.com/PrefectHQ/graphs/assets/6776415/0cecc14a-1d4c-4874-9cf7-e11b2bce6084

Now the updatePosition function is always called after the child render functions are.

https://github.com/PrefectHQ/graphs/assets/6776415/67ae0dd1-1a7a-46d8-9bbe-ff64acf1d171

