### PR TITLE
rename types to be graphs specific

### DIFF
--- a/src/factories/artifact.ts
+++ b/src/factories/artifact.ts
@@ -1,6 +1,5 @@
-import { Container } from 'pixi.js'
 import { artifactNodeFactory } from '@/factories/artifactNode'
-import { Artifact } from '@/models/artifact'
+import { RunGraphArtifact } from '@/models/artifact'
 import { emitter } from '@/objects/events'
 import { isSelected, selectItem } from '@/objects/selection'
 
@@ -11,7 +10,7 @@ type ArtifactFactoryOptions = {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export async function artifactFactory(artifact: Artifact, { cullAtZoomThreshold = true }: ArtifactFactoryOptions = {}) {
+export async function artifactFactory(artifact: RunGraphArtifact, { cullAtZoomThreshold = true }: ArtifactFactoryOptions = {}) {
   const { element, render: renderArtifactNode } = await artifactNodeFactory({ cullAtZoomThreshold })
 
   let selected = false

--- a/src/factories/flowRunArtifact.ts
+++ b/src/factories/flowRunArtifact.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_ROOT_ARTIFACT_BOTTOM_OFFSET } from '@/consts'
 import { ArtifactFactory, artifactFactory } from '@/factories/artifact'
 import { ArtifactClusterFactory, ArtifactClusterFactoryRenderProps, artifactClusterFactory } from '@/factories/artifactCluster'
-import { Artifact } from '@/models'
+import { RunGraphArtifact } from '@/models'
 import { waitForApplication, waitForViewport } from '@/objects'
 import { waitForConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
@@ -10,7 +10,7 @@ import { layout, waitForSettings } from '@/objects/settings'
 
 export type FlowRunArtifactFactory = Awaited<ReturnType<typeof flowRunArtifactFactory>>
 
-type ArtifactFactoryOptions = { type: 'artifact', artifact: Artifact } | { type: 'cluster' }
+type ArtifactFactoryOptions = { type: 'artifact', artifact: RunGraphArtifact } | { type: 'cluster' }
 
 type FactoryType<T> = T extends { type: 'artifact' }
   ? ArtifactFactory

--- a/src/factories/flowRunArtifacts.ts
+++ b/src/factories/flowRunArtifacts.ts
@@ -4,7 +4,7 @@ import { DEFAULT_ROOT_ARTIFACT_COLLISION_THROTTLE, DEFAULT_ROOT_ARTIFACT_Z_INDEX
 import { ArtifactFactory } from '@/factories/artifact'
 import { ArtifactClusterFactory } from '@/factories/artifactCluster'
 import { flowRunArtifactFactory, FlowRunArtifactFactory } from '@/factories/flowRunArtifact'
-import { Artifact } from '@/models'
+import { RunGraphArtifact } from '@/models'
 import { waitForApplication, waitForViewport } from '@/objects'
 import { waitForConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
@@ -21,12 +21,12 @@ export async function flowRunArtifactsFactory() {
   const clusterNodes: ArtifactClusterFactory[] = []
 
   let container: Container | null = null
-  let internalData: Artifact[] | null = null
+  let internalData: RunGraphArtifact[] | null = null
   let nonTemporalAlignmentEngaged = false
 
   emitter.on('viewportMoved', () => update())
 
-  async function render(newData?: Artifact[]): Promise<void> {
+  async function render(newData?: RunGraphArtifact[]): Promise<void> {
     if (container) {
       container.visible = !settings.disableArtifacts
     }
@@ -56,7 +56,7 @@ export async function flowRunArtifactsFactory() {
     await Promise.all(promises)
   }
 
-  async function createArtifact(artifact: Artifact): Promise<void> {
+  async function createArtifact(artifact: RunGraphArtifact): Promise<void> {
     if (artifacts.has(artifact.id)) {
       return artifacts.get(artifact.id)!.render()
     }

--- a/src/factories/flowRunState.ts
+++ b/src/factories/flowRunState.ts
@@ -1,6 +1,6 @@
 import { ColorSource, Container } from 'pixi.js'
 import { rectangleFactory } from '@/factories/rectangle'
-import { StateEvent } from '@/models/states'
+import { RunGraphStateEvent } from '@/models/states'
 import { waitForApplication, waitForViewport } from '@/objects'
 import { waitForConfig } from '@/objects/config'
 import { emitter } from '@/objects/events'
@@ -20,7 +20,7 @@ type StateRectangleRenderProps = {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export async function flowRunStateFactory(state: StateEvent, options?: FlowRunStateFactoryOptions) {
+export async function flowRunStateFactory(state: RunGraphStateEvent, options?: FlowRunStateFactoryOptions) {
   const application = await waitForApplication()
   const viewport = await waitForViewport()
   const config = await waitForConfig()

--- a/src/factories/flowRunStates.ts
+++ b/src/factories/flowRunStates.ts
@@ -1,18 +1,18 @@
 import { Container } from 'pixi.js'
 import { DEFAULT_ROOT_FLOW_STATE_Z_INDEX } from '@/consts'
 import { FlowRunStateFactory, flowRunStateFactory } from '@/factories/flowRunState'
-import { StateEvent } from '@/models/states'
+import { RunGraphStateEvent } from '@/models/states'
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function flowRunStatesFactory() {
   const element = new Container()
 
   const states = new Map<string, FlowRunStateFactory>()
-  let internalData: StateEvent[] | null = null
+  let internalData: RunGraphStateEvent[] | null = null
 
   element.zIndex = DEFAULT_ROOT_FLOW_STATE_Z_INDEX
 
-  async function render(newStateData?: StateEvent[]): Promise<void> {
+  async function render(newStateData?: RunGraphStateEvent[]): Promise<void> {
     if (newStateData) {
       internalData = newStateData
     }
@@ -30,7 +30,7 @@ export function flowRunStatesFactory() {
     await Promise.all(promises)
   }
 
-  async function createState(state: StateEvent, currIndex: number): Promise<void> {
+  async function createState(state: RunGraphStateEvent, currIndex: number): Promise<void> {
     const nextState = internalData && internalData.length >= currIndex + 1 && internalData[currIndex + 1]
     const options = nextState ? { end: nextState.occurred } : undefined
 

--- a/src/factories/node.ts
+++ b/src/factories/node.ts
@@ -4,7 +4,7 @@ import { animationFactory } from '@/factories/animation'
 import { artifactFactory, ArtifactFactory } from '@/factories/artifact'
 import { FlowRunContainer, flowRunContainerFactory } from '@/factories/nodeFlowRun'
 import { TaskRunContainer, taskRunContainerFactory } from '@/factories/nodeTaskRun'
-import { Artifact } from '@/models'
+import { RunGraphArtifact } from '@/models'
 import { BoundsContainer } from '@/models/boundsContainer'
 import { Pixels } from '@/models/layout'
 import { RunGraphNode } from '@/models/RunGraph'
@@ -84,7 +84,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
     return container
   }
 
-  async function createArtifacts(artifactsData?: Artifact[]): Promise<void> {
+  async function createArtifacts(artifactsData?: RunGraphArtifact[]): Promise<void> {
     if (!artifactsData || settings.disableArtifacts) {
       return
     }
@@ -104,7 +104,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
     alignArtifacts()
   }
 
-  async function createArtifact(artifact: Artifact): Promise<void> {
+  async function createArtifact(artifact: RunGraphArtifact): Promise<void> {
     if (artifacts.has(artifact.id)) {
       return artifacts.get(artifact.id)!.render()
     }

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -1,7 +1,7 @@
 import { ColorSource } from 'pixi.js'
-import { Artifact } from '@/models'
+import { RunGraphArtifact } from '@/models'
 import { GraphItemSelection } from '@/models/selection'
-import { StateEvent, StateType } from '@/models/states'
+import { RunGraphStateEvent, StateType } from '@/models/states'
 import { ViewportDateRange } from '@/models/viewport'
 
 export type RunGraphProps = {
@@ -16,8 +16,8 @@ export type RunGraphData = {
   start_time: Date,
   end_time: Date | null,
   nodes: RunGraphNodes,
-  artifacts?: Artifact[],
-  state_events?: StateEvent[],
+  artifacts?: RunGraphArtifact[],
+  state_events?: RunGraphStateEvent[],
 }
 
 export type RunGraphNodes = Map<string, RunGraphNode>
@@ -31,7 +31,7 @@ export type RunGraphNode = {
   end_time: Date | null,
   parents: RunGraphEdge[],
   children: RunGraphEdge[],
-  artifacts?: Artifact[],
+  artifacts?: RunGraphArtifact[],
 }
 
 export type RunGraphEdge = {
@@ -98,7 +98,7 @@ export type RunGraphStyles = {
   playheadWidth?: number,
   playheadColor?: ColorSource,
   node?: (node: RunGraphNode) => RunGraphNodeStyles,
-  state?: (state: StateEvent) => RunGraphStateStyles,
+  state?: (state: RunGraphStateEvent) => RunGraphStateStyles,
 }
 
 export type RunGraphConfig = {

--- a/src/models/artifact.ts
+++ b/src/models/artifact.ts
@@ -9,7 +9,7 @@ export const artifactTypes = [
 
 export type ArtifactType = typeof artifactTypes[number]
 
-export type Artifact = {
+export type RunGraphArtifact = {
   id: string,
   created: Date,
   key: string,

--- a/src/models/states.ts
+++ b/src/models/states.ts
@@ -12,7 +12,7 @@ export const stateType = [
 
 export type StateType = typeof stateType[number]
 
-export type StateEvent = {
+export type RunGraphStateEvent = {
   id: string,
   occurred: Date,
   type: StateType,


### PR DESCRIPTION
Since downstream artifacts already use generic `Artifact` and `StateEvent` is also out of sync. This updates them to `RunGraphArtifact` and `RunGraphStateEvent`. Now in the ui-library mappers they'll be more readable and less prone to clashing.