### PR TITLE
Add position to artifact cluster selections

### DIFF
--- a/src/factories/artifactCluster.ts
+++ b/src/factories/artifactCluster.ts
@@ -22,7 +22,13 @@ export async function artifactClusterFactory() {
 
   element.on('click', event => {
     event.stopPropagation()
-    selectItem({ kind: 'artifacts', ids: currentIds })
+
+    const position = {
+      x: element.position.x + element.width / 2,
+      y: element.position.y + element.height,
+    }
+
+    selectItem({ kind: 'artifacts', ids: currentIds, position })
   })
   emitter.on('itemSelected', () => {
     const isCurrentlySelected = isSelected({ kind: 'artifacts', ids: currentIds })

--- a/src/factories/artifactNode.ts
+++ b/src/factories/artifactNode.ts
@@ -78,6 +78,7 @@ export async function artifactNodeFactory({ cullAtZoomThreshold }: ArtifactNodeF
 
   async function renderArtifactNode(): Promise<Container> {
     if (!name) {
+      label.visible = false
       return label
     }
 
@@ -97,6 +98,7 @@ export async function artifactNodeFactory({ cullAtZoomThreshold }: ArtifactNodeF
     label.tint = artifactTextColor
     label.scale.set(0.75)
     label.position = { x, y }
+    label.visible = true
 
     return label
   }

--- a/src/models/artifact.ts
+++ b/src/models/artifact.ts
@@ -12,7 +12,7 @@ export type ArtifactType = typeof artifactTypes[number]
 export type RunGraphArtifact = {
   id: string,
   created: Date,
-  key: string,
+  key?: string,
   type: ArtifactType,
 }
 

--- a/src/models/selection.ts
+++ b/src/models/selection.ts
@@ -19,6 +19,7 @@ export function isArtifactSelection(selection: GraphItemSelection): selection is
 export type ArtifactsSelection = {
   kind: 'artifacts',
   ids: string[],
+  position?: { x: number, y: number },
 }
 export function isArtifactsSelection(selection: GraphItemSelection): selection is ArtifactsSelection {
   return selection.kind === 'artifacts'


### PR DESCRIPTION
Also makes the artifact key optional, since some artifacts don't come with one. A simple icon only node will display in those cases.