### PR TITLE
fix: state selection not clearing hovered state

### DIFF
--- a/src/factories/flowRunState.ts
+++ b/src/factories/flowRunState.ts
@@ -64,11 +64,14 @@ export async function flowRunStateFactory(state: RunGraphStateEvent, options?: F
     scale = updated
     render()
   })
-  emitter.on('itemSelected', item => {
+  emitter.on('itemSelected', () => {
     const isCurrentlySelected = isSelected({ kind: 'state', ...state })
 
     if (isCurrentlySelected !== selected) {
       selected = isCurrentlySelected
+      // clear the hovered state to account for the popover div
+      // that prevents the mouseleave event in prefect-ui-library
+      hovered = false
       render()
     }
   })


### PR DESCRIPTION
For state bars, we need to clear the hovered state on select since the popover in ui-library uses an invisible cover div. The div prevents the `mouseleave` event from firing so the hovered state get's stuck.