### PR TITLE
Enhancement: handle nodeless centering and live running state

### DIFF
--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -130,30 +130,26 @@ async function centerViewportOnStartAndEnd({ animate }: CenterViewportParameters
   const viewport = await waitForViewport()
   const graphScale = await waitForScale()
 
-  console.log({
-    startDate: data.start_time.getTime(),
-    endDate: data.end_time?.getTime(),
-    state: data.states?.map((state) => {
-      return { time: state.timestamp.getTime(), name: state.name }
-    }),
-  })
+  let startX = graphScale(data.start_time) - config.styles.columnGap
+  let endX = graphScale(data.end_time ?? new Date()) + config.styles.columnGap
 
-  let x = 0
+  if (startX > endX) {
+    const temp = startX
 
-  if (data.end_time) {
-    const startX = graphScale(data.start_time)
-    const endX = graphScale(data.end_time)
-
-    x = startX + (endX - startX) / 2
-  } else {
-    x = graphScale(data.start_time) + viewport.width / 2
+    startX = endX
+    endX = temp
   }
+
+  const width = endX - startX
+  const x = startX + width / 2
+  const scale = viewport.findFit(width, 0)
 
   viewport.animate({
     position: {
       x,
       y: 0,
     },
+    scale,
     time: animate ? config.animationDuration : 0,
     ease: 'easeInOutQuad',
     removeOnInterrupt: true,

--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -6,6 +6,7 @@ import { waitForApplication } from '@/objects/application'
 import { waitForConfig } from '@/objects/config'
 import { cull, uncull } from '@/objects/culling'
 import { emitter, waitForEvent } from '@/objects/events'
+import { waitForRunData } from '@/objects/nodes'
 import { waitForScale } from '@/objects/scale'
 import { waitForSettings } from '@/objects/settings'
 import { waitForStage } from '@/objects/stage'
@@ -70,25 +71,42 @@ type CenterViewportParameters = {
 
 export async function centerViewport({ animate }: CenterViewportParameters = {}): Promise<void> {
   const viewport = await waitForViewport()
-  const config = await waitForConfig()
+
   const container = viewport.getChildByName(DEFAULT_NODES_CONTAINER_NAME)
 
   if (!container) {
     throw new Error('Nodes container not found')
   }
 
-  const guidesOffset = config.styles.guideTextSize + config.styles.guideTextTopPadding
-
   uncull()
   const { x, y, width, height } = container.getLocalBounds()
+
+  // if the container doesn't have a size attempt to center to flow state
+  if (!width || !height) {
+    centerViewportOnStartAndEnd({ animate })
+
+    return
+  }
+
+  centerViewportOnNodes({ x, y, width, height, animate })
+}
+
+type CenterViewportOnNodesParameters = {
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  animate?: boolean,
+}
+
+async function centerViewportOnNodes({ x, y, width, height, animate }: CenterViewportOnNodesParameters): Promise<void> {
+  const config = await waitForConfig()
+  const viewport = await waitForViewport()
+
+  const guidesOffset = config.styles.guideTextSize + config.styles.guideTextTopPadding
   const widthWithGap = width + config.styles.columnGap * 2
   const heightWithGap = height + config.styles.rowGap * 2 + guidesOffset * 2
   const scale = viewport.findFit(widthWithGap, heightWithGap)
-
-  // if the container doesn't have a size we cannot do anything here
-  if (!width || !height) {
-    return
-  }
 
   viewport.animate({
     position: {
@@ -104,7 +122,46 @@ export async function centerViewport({ animate }: CenterViewportParameters = {})
       updateViewportDateRange()
     },
   })
+}
 
+async function centerViewportOnStartAndEnd({ animate }: CenterViewportParameters): Promise<void> {
+  const data = await waitForRunData()
+  const config = await waitForConfig()
+  const viewport = await waitForViewport()
+  const graphScale = await waitForScale()
+
+  console.log({
+    startDate: data.start_time.getTime(),
+    endDate: data.end_time?.getTime(),
+    state: data.states?.map((state) => {
+      return { time: state.timestamp.getTime(), name: state.name }
+    }),
+  })
+
+  let x = 0
+
+  if (data.end_time) {
+    const startX = graphScale(data.start_time)
+    const endX = graphScale(data.end_time)
+
+    x = startX + (endX - startX) / 2
+  } else {
+    x = graphScale(data.start_time) + viewport.width / 2
+  }
+
+  viewport.animate({
+    position: {
+      x,
+      y: 0,
+    },
+    time: animate ? config.animationDuration : 0,
+    ease: 'easeInOutQuad',
+    removeOnInterrupt: true,
+    callbackOnComplete: () => {
+      cull()
+      updateViewportDateRange()
+    },
+  })
 }
 
 export async function waitForViewport(): Promise<Viewport> {

--- a/src/utilities/getInitialHorizontalScaleMultiplier.ts
+++ b/src/utilities/getInitialHorizontalScaleMultiplier.ts
@@ -7,8 +7,12 @@ export function getInitialHorizontalScaleMultiplier({ start_time, end_time, node
 
   const nodeHeight = config.styles.nodeHeight + config.styles.rowGap
   const apxConcurrencyFactor = 0.5
+  const emptyNodesHeightMultiplier = 4
 
-  const apxNodesHeight = nodes.size * nodeHeight * apxConcurrencyFactor
+  const apxNodesHeight = nodes.size > 0
+    ? nodes.size * nodeHeight * apxConcurrencyFactor
+    : nodeHeight * emptyNodesHeightMultiplier
+
   const widthWeWant = apxNodesHeight * aspectRatio
 
   const idealMultiplier = widthWeWant / (seconds * DEFAULT_TIME_COLUMN_SIZE_PIXELS)


### PR DESCRIPTION
If there are no nodes, a default scale multiplier is used and the viewport will center using start/end times instead of the nodes container.

This also updates the state bar for a "running" state to terminate at the playhead if the flow is live.

No change for a flow with nodes:
<img width="1241" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6776415/15e9d601-c0ed-4be3-b866-e29f8166fca7">

A very short flow with no nodes, hitting the max zoom in:
<img width="1241" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6776415/1e1ab0c6-73ed-4d0c-b47a-6e5b11a047a7">

A longer (30 seconds) flow freshly reloaded:
<img width="1241" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6776415/dc0ca7ed-65e1-414b-9a08-0078eb0b469f">


A live flow running for 30 seconds with no nodes:
https://github.com/PrefectHQ/graphs/assets/6776415/2ee8b003-74cd-41f8-9884-3bed217704c7

