### PR TITLE
Enhancement: Add subflow artifacts

### DIFF
--- a/src/factories/artifact.ts
+++ b/src/factories/artifact.ts
@@ -7,10 +7,14 @@ export type ArtifactFactory = Awaited<ReturnType<typeof artifactFactory>>
 
 type ArtifactFactoryOptions = {
   cullAtZoomThreshold?: boolean,
+  enableLocalClickHandling?: boolean,
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export async function artifactFactory(artifact: RunGraphArtifact, { cullAtZoomThreshold = true }: ArtifactFactoryOptions = {}) {
+export async function artifactFactory(artifact: RunGraphArtifact, {
+  cullAtZoomThreshold = true,
+  enableLocalClickHandling = false,
+}: ArtifactFactoryOptions = {}) {
   const { element, render: renderArtifactNode } = await artifactNodeFactory({ cullAtZoomThreshold })
 
   let selected = false
@@ -18,10 +22,12 @@ export async function artifactFactory(artifact: RunGraphArtifact, { cullAtZoomTh
   element.eventMode = 'static'
   element.cursor = 'pointer'
 
-  element.on('click', event => {
-    event.stopPropagation()
-    selectItem({ kind: 'artifact', id: artifact.id })
-  })
+  if (enableLocalClickHandling) {
+    element.on('click', event => {
+      event.stopPropagation()
+      selectItem({ kind: 'artifact', id: artifact.id })
+    })
+  }
 
   emitter.on('itemSelected', () => {
     const isCurrentlySelected = isSelected({ kind: 'artifact', id: artifact.id })

--- a/src/factories/artifactCluster.ts
+++ b/src/factories/artifactCluster.ts
@@ -1,6 +1,6 @@
 import { artifactNodeFactory } from '@/factories/artifactNode'
 import { emitter } from '@/objects/events'
-import { isSelected, selectItem } from '@/objects/selection'
+import { isSelected } from '@/objects/selection'
 
 export type ArtifactClusterFactory = Awaited<ReturnType<typeof artifactClusterFactory>>
 
@@ -20,18 +20,6 @@ export async function artifactClusterFactory() {
   element.eventMode = 'static'
   element.cursor = 'pointer'
 
-  element.on('click', event => {
-    event.stopPropagation()
-
-    const position = {
-      x: element.position.x,
-      y: element.position.y,
-      width: element.width,
-      height: element.height,
-    }
-
-    selectItem({ kind: 'artifacts', ids: currentIds, position })
-  })
   emitter.on('itemSelected', () => {
     const isCurrentlySelected = isSelected({ kind: 'artifacts', ids: currentIds })
 

--- a/src/factories/node.ts
+++ b/src/factories/node.ts
@@ -74,7 +74,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
     ])
 
     if (artifactsContainer) {
-      artifactsContainer.visible = !settings.disableArtifacts
+      artifactsContainer.visible = layout.isTemporal() ? !settings.disableArtifacts : false
     }
 
     if (node.end_time) {
@@ -85,7 +85,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
   }
 
   async function createArtifacts(artifactsData?: RunGraphArtifact[]): Promise<void> {
-    if (!artifactsData || settings.disableArtifacts) {
+    if (!artifactsData || settings.disableArtifacts || !layout.isTemporal()) {
       return
     }
 
@@ -109,7 +109,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
       return artifacts.get(artifact.id)!.render()
     }
 
-    const factory = await artifactFactory(artifact)
+    const factory = await artifactFactory(artifact, { enableLocalClickHandling: true })
 
     artifacts.set(artifact.id, factory)
 

--- a/src/factories/runEvents.ts
+++ b/src/factories/runEvents.ts
@@ -27,6 +27,7 @@ export async function runEventsFactory({ isRoot, parentStartDate }: RunEventsFac
   let internalData: RunGraphEvent[] | null = null
 
   emitter.on('layoutSettingsUpdated', () => render())
+  emitter.on('scaleUpdated', () => update())
 
   async function render(newData?: RunGraphEvent[]): Promise<void> {
     if (!layout.isTemporal()) {

--- a/src/objects/flowRunArtifacts.ts
+++ b/src/objects/flowRunArtifacts.ts
@@ -1,11 +1,17 @@
-import { flowRunArtifactsFactory } from '@/factories/flowRunArtifacts'
+import { DEFAULT_ROOT_ARTIFACT_Z_INDEX } from '@/consts'
+import { runArtifactsFactory } from '@/factories/runArtifacts'
 import { RunGraphData } from '@/models/RunGraph'
+import { waitForApplication } from '@/objects/application'
 import { emitter } from '@/objects/events'
 import { waitForRunData } from '@/objects/nodes'
 
 export async function startFlowRunArtifacts(): Promise<void> {
+  const application = await waitForApplication()
   const data = await waitForRunData()
-  const { render: renderArtifacts } = await flowRunArtifactsFactory()
+  const { element, render: renderArtifacts, update } = await runArtifactsFactory({ isRoot: true })
+
+  element.zIndex = DEFAULT_ROOT_ARTIFACT_Z_INDEX
+  application.stage.addChild(element)
 
   function render(newData?: RunGraphData): void {
     renderArtifacts(newData?.artifacts)
@@ -15,10 +21,11 @@ export async function startFlowRunArtifacts(): Promise<void> {
     render(data)
   }
 
+  emitter.on('viewportMoved', () => update())
+
   emitter.on('runDataCreated', (data) => render(data))
   emitter.on('runDataUpdated', (data) => render(data))
   emitter.on('configUpdated', () => render())
-  emitter.on('layoutSettingsUpdated', () => render())
 }
 
 export function stopFlowRunArtifacts(): void {

--- a/src/objects/flowRunEvents.ts
+++ b/src/objects/flowRunEvents.ts
@@ -35,7 +35,6 @@ export async function startFlowRunEvents(): Promise<void> {
 
   emitter.on('configUpdated', () => render())
   emitter.on('viewportMoved', () => update())
-  emitter.on('scaleUpdated', () => update())
 
   stopEventData = response.stop
 


### PR DESCRIPTION
Also opts to just hide artifacts if in a non-temporal layout. I could probably get them to appear OK when subflows are expanded, but for now I'm opting to make those views strictly about dependency paths.

https://github.com/PrefectHQ/graphs/assets/6776415/cb3e6db2-ad08-487b-8a54-4ddfdb879722

