### PR TITLE
bring back borders to subflows

### DIFF
--- a/src/factories/border.ts
+++ b/src/factories/border.ts
@@ -8,6 +8,7 @@ export type BorderStyle = {
   stroke: number,
   radius?: number,
   color?: ColorSource,
+  roundedTop?: boolean,
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -50,7 +51,7 @@ export function borderFactory() {
   container.addChild(bottom)
 
   async function render(style: BorderStyle): Promise<Container> {
-    const { radius = 0, color = '#fff', stroke, width, height } = style
+    const { radius = 0, color = '#fff', stroke, width, height, roundedTop } = style
     const maxSize = Math.min(width, height)
     const size = radius * 2 > maxSize ? maxSize / 2 : radius
 
@@ -68,6 +69,7 @@ export function borderFactory() {
       width,
       height,
       size,
+      roundedTop,
     })
 
     updateBorders({
@@ -76,6 +78,7 @@ export function borderFactory() {
       height,
       size,
       stroke,
+      roundedTop,
     })
 
     setTint(color)
@@ -88,9 +91,18 @@ export function borderFactory() {
     width: number,
     height: number,
     size: number,
+    roundedTop?: boolean,
   }
 
-  function updateCorners({ texture, width, height, size }: UpdateCorners): void {
+  function updateCorners({ texture, width, height, size, roundedTop }: UpdateCorners): void {
+    if (roundedTop) {
+      bottomLeft.visible = false
+      bottomRight.visible = false
+    } else {
+      bottomLeft.visible = true
+      bottomRight.visible = true
+    }
+
     topLeft.texture = texture
     topRight.texture = texture
     bottomLeft.texture = texture
@@ -108,9 +120,10 @@ export function borderFactory() {
     height: number,
     size: number,
     stroke: number,
+    roundedTop?: boolean,
   }
 
-  function updateBorders({ texture, size, width, height, stroke }: UpdateBorders): void {
+  function updateBorders({ texture, size, width, height, stroke, roundedTop }: UpdateBorders): void {
     const sidesHeight = Math.max(height - size * 2, 0)
     const topAndBottomWidth = Math.max(width - size * 2, 0)
 
@@ -120,19 +133,19 @@ export function borderFactory() {
     bottom.texture = texture
 
     left.position.set(0, size)
-    left.height = sidesHeight
+    left.height = roundedTop ? Math.max(height - size, 0) : sidesHeight
     left.width = stroke
 
     right.position.set(width - stroke, size)
-    right.height = sidesHeight
+    right.height = roundedTop ? Math.max(height - size, 0) : sidesHeight
     right.width = stroke
 
     top.position.set(size, 0)
     top.width = topAndBottomWidth
     top.height = stroke
 
-    bottom.position.set(size, height - stroke)
-    bottom.width = topAndBottomWidth
+    bottom.position.set(roundedTop ? 0 : size, height - stroke)
+    bottom.width = roundedTop ? Math.max(width, 0) : topAndBottomWidth
     bottom.height = stroke
   }
 

--- a/src/factories/nodeFlowRun.ts
+++ b/src/factories/nodeFlowRun.ts
@@ -105,6 +105,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     const { background = '#fff' } = config.styles.node(node)
     const { width, height: nodeHeights } = getNodesSize()
     const { height: nodeLayersHeight } = getSize()
+    const { nodeBorderRadius } = config.styles
 
     const strokeWidth = 2
     border.position = { x: -strokeWidth, y: -strokeWidth }
@@ -117,9 +118,8 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
       width: width + strokeWidth * 2,
       height,
       stroke: strokeWidth,
-      radius: config.styles.nodeBorderRadius,
+      radius: [nodeBorderRadius, nodeBorderRadius, 0, 0],
       color: background,
-      roundedTop: true,
     })
   }
 

--- a/src/factories/nodeFlowRun.ts
+++ b/src/factories/nodeFlowRun.ts
@@ -1,3 +1,4 @@
+import { borderFactory } from '@/factories/border'
 import { dataFactory } from '@/factories/data'
 import { eventDataFactory } from '@/factories/eventData'
 import { nodeLabelFactory } from '@/factories/label'
@@ -13,6 +14,7 @@ import { NodeSize } from '@/models/layout'
 import { RunGraphFetchEventsOptions, RunGraphNode } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
 import { cull } from '@/objects/culling'
+import { layout } from '@/objects/settings'
 
 export type FlowRunContainer = Awaited<ReturnType<typeof flowRunContainerFactory>>
 
@@ -24,6 +26,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   const { element: bar, render: renderBar } = await nodeBarFactory()
   const { element: label, render: renderLabelText } = await nodeLabelFactory()
   const { element: arrowButton, render: renderArrowButtonContainer } = await nodeArrowButtonFactory()
+  const { element: border, render: renderBorderContainer } = await borderFactory()
 
   const { element: nodesContainer, render: renderNodes, getSize: getNodesSize, stopWorker: stopNodesWorker } = await nodesContainerFactory()
   const { element: nodesState, render: renderNodesState } = await runStatesFactory()
@@ -34,15 +37,21 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   bar.zIndex = 2
   label.zIndex = 3
   arrowButton.zIndex = 3
+  border.zIndex = 0
+
   nodesContainer.zIndex = 1
   nodesState.zIndex = 1
   nodesEvents.zIndex = 2
   nodesArtifacts.zIndex = 2
 
+  border.eventMode = 'none'
+  border.cursor = 'default'
+
   const { start: startData, stop: stopData } = await dataFactory(node.id, data => {
     renderNodes(data)
     renderStates(data.states)
     renderArtifacts(data.artifacts)
+    renderBorder()
   })
 
   function getEventFactoryOptions(): RunGraphFetchEventsOptions {
@@ -92,6 +101,28 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     }
   }
 
+  async function renderBorder(): Promise<void> {
+    const { background = '#fff' } = config.styles.node(node)
+    const { width, height: nodeHeights } = getNodesSize()
+    const { height: nodeLayersHeight } = getSize()
+
+    const strokeWidth = 2
+    border.position = { x: -strokeWidth, y: -strokeWidth }
+
+    const height = layout.isTemporal()
+      ? nodeLayersHeight + strokeWidth * 2
+      : nodeHeights + strokeWidth * 2
+
+    await renderBorderContainer({
+      width: width + strokeWidth * 2,
+      height,
+      stroke: strokeWidth,
+      radius: config.styles.nodeBorderRadius,
+      color: background,
+      roundedTop: true,
+    })
+  }
+
   async function renderStates(data?: RunGraphStateEvent[]): Promise<void> {
     const { width: nodesWidth, height } = getSize()
 
@@ -137,6 +168,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     container.addChild(nodesEvents)
     container.addChild(nodesArtifacts)
     container.addChild(nodesContainer)
+    container.addChild(border)
 
     await Promise.all([
       startData(),
@@ -153,6 +185,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     container.removeChild(nodesEvents)
     container.removeChild(nodesArtifacts)
     container.removeChild(nodesContainer)
+    container.removeChild(border)
     stopNodesWorker()
 
     await Promise.all([
@@ -205,6 +238,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
       renderStates()
       renderEvents()
       renderArtifacts()
+      renderBorder()
     }
 
     const size = getSize()


### PR DESCRIPTION
Adds back a border, but with a flat bottom (instead of rounded) so that the state doesn't have to accommodate the curve.

https://github.com/PrefectHQ/graphs/assets/6776415/70e55a2c-e16d-4d5c-827d-c019e5c6524a

