### PR TITLE
Bugfix: await cluster rendering

### DIFF
--- a/src/utilities/detectHorizontalCollisions.ts
+++ b/src/utilities/detectHorizontalCollisions.ts
@@ -89,7 +89,7 @@ export async function clusterHorizontalCollisions({ items, createCluster }: Clus
     const ids = [...prevIds, ...currentIds]
     const date = getCenteredDate(ids)
 
-    clusterNode.render({ ids, date })
+    await clusterNode.render({ ids, date })
 
     return clusterNode
   }


### PR DESCRIPTION
Need to await the render call of a cluster so that dimensions are available for the subsequent rounds of collision checks.