### PR TITLE
Enhancement: adaptive artifacts placement

### DIFF
--- a/src/factories/nodeFlowRun.ts
+++ b/src/factories/nodeFlowRun.ts
@@ -33,6 +33,9 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   const { element: nodesEvents, render: renderNodesEvents, update: updateNodesEvents } = await runEventsFactory({ parentStartDate: node.start_time })
   const { element: nodesArtifacts, render: renderNodesArtifacts, update: updateNodesArtifacts } = await runArtifactsFactory({ parentStartDate: node.start_time })
 
+  let hasEvents = false
+  let hasArtifacts = false
+
   container.sortableChildren = true
   bar.zIndex = 2
   label.zIndex = 3
@@ -48,6 +51,8 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   border.cursor = 'default'
 
   const { start: startData, stop: stopData } = await dataFactory(node.id, data => {
+    hasArtifacts = !!data.artifacts && data.artifacts.length > 0
+
     renderNodes(data)
     renderStates(data.states)
     renderArtifacts(data.artifacts)
@@ -61,6 +66,8 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     }
   }
   const { start: startEventsData, stop: stopEventsData } = await eventDataFactory(node.id, data => {
+    hasEvents = data.length > 0
+
     renderEvents(data)
   }, getEventFactoryOptions)
 
@@ -149,9 +156,11 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
   }
 
   async function renderArtifacts(data?: RunGraphArtifact[]): Promise<void> {
+    const { eventTargetSize, flowStateSelectedBarHeight } = config.styles
     const { height } = getSize()
 
-    const y = height - config.styles.eventTargetSize
+    const y = height - (hasEvents ? eventTargetSize : flowStateSelectedBarHeight)
+
     nodesArtifacts.position = { x: 0, y }
 
     if (data) {
@@ -256,10 +265,11 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
       artifactIconSize,
     } = config.styles
 
-    const artifactsHeight = artifactIconSize + artifactPaddingY * 2
+    const artifactsHeight = hasArtifacts ? artifactIconSize + artifactPaddingY * 2 : 0
+    const eventsHeight = hasEvents ? eventTargetSize : 0
 
     const nodesHeight = isOpen
-      ? nodes.height + artifactsHeight + eventTargetSize + nodesPadding * 2
+      ? nodes.height + artifactsHeight + eventsHeight + nodesPadding * 2
       : 0
     const nodesWidth = isOpen ? nodes.width : 0
     const flowRunNodeHeight = nodeHeight

--- a/src/objects/flowRunEvents.ts
+++ b/src/objects/flowRunEvents.ts
@@ -4,7 +4,7 @@ import { runEventsFactory } from '@/factories/runEvents'
 import { RunGraphEvent } from '@/models'
 import { waitForApplication } from '@/objects/application'
 import { waitForConfig } from '@/objects/config'
-import { EventKey, emitter } from '@/objects/events'
+import { EventKey, emitter, waitForEvent } from '@/objects/events'
 import { waitForSettings } from '@/objects/settings'
 
 let stopEventData: (() => void) | null = null
@@ -45,4 +45,12 @@ export function stopFlowRunEvents(): void {
   stopEventData?.()
   stopEventData = null
   rootGraphEvents = null
+}
+
+export async function waitForRunEvents(): Promise<RunGraphEvent[] | null> {
+  if (rootGraphEvents) {
+    return rootGraphEvents
+  }
+
+  return await waitForEvent('eventDataCreated')
 }


### PR DESCRIPTION
Slight enhancement to place artifacts lower if there are no events. For subflows, it'll remove the gap affordance if there are no events and/or artifacts.

With events:
<img width="670" alt="Screenshot 2024-03-08 at 11 39 31 AM" src="https://github.com/PrefectHQ/graphs/assets/6776415/a687e30f-d7cd-49d1-b6fe-f578d618785a">

Without events:
<img width="768" alt="Screenshot 2024-03-08 at 11 40 30 AM" src="https://github.com/PrefectHQ/graphs/assets/6776415/40a01cd5-4f15-4ab6-8c3a-353e74f704fc">

I would like to figure out a way to get those on the same row, but the complexity is a little to hard core atm.