### PR TITLE
Bugfix: artifact cluster measurements on emit

### DIFF
--- a/src/factories/artifactCluster.ts
+++ b/src/factories/artifactCluster.ts
@@ -1,3 +1,4 @@
+import { ArtifactFactory } from '@/factories/artifact'
 import { artifactNodeFactory } from '@/factories/artifactNode'
 import { emitter } from '@/objects/events'
 import { isSelected } from '@/objects/selection'
@@ -7,6 +8,12 @@ export type ArtifactClusterFactory = Awaited<ReturnType<typeof artifactClusterFa
 export type ArtifactClusterFactoryRenderProps = {
   ids: string[],
   date: Date,
+}
+
+export function isArtifactClusterFactory(
+  factory: ArtifactFactory | ArtifactClusterFactory,
+): factory is ArtifactClusterFactory {
+  return 'isCluster' in factory
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/src/factories/artifactCluster.ts
+++ b/src/factories/artifactCluster.ts
@@ -1,4 +1,3 @@
-import { ArtifactFactory } from '@/factories/artifact'
 import { artifactNodeFactory } from '@/factories/artifactNode'
 import { emitter } from '@/objects/events'
 import { isSelected } from '@/objects/selection'
@@ -8,12 +7,6 @@ export type ArtifactClusterFactory = Awaited<ReturnType<typeof artifactClusterFa
 export type ArtifactClusterFactoryRenderProps = {
   ids: string[],
   date: Date,
-}
-
-export function isArtifactClusterFactory(
-  factory: ArtifactFactory | ArtifactClusterFactory,
-): factory is ArtifactClusterFactory {
-  return 'isCluster' in factory
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/src/factories/flowRunArtifact.ts
+++ b/src/factories/flowRunArtifact.ts
@@ -1,5 +1,5 @@
 import { ArtifactFactory, artifactFactory } from '@/factories/artifact'
-import { ArtifactClusterFactory, ArtifactClusterFactoryRenderProps, artifactClusterFactory } from '@/factories/artifactCluster'
+import { ArtifactClusterFactory, ArtifactClusterFactoryRenderProps, artifactClusterFactory, isArtifactClusterFactory } from '@/factories/artifactCluster'
 import { ArtifactSelection, ArtifactsSelection, RunGraphArtifact } from '@/models'
 import { waitForApplication, waitForViewport } from '@/objects'
 import { waitForConfig } from '@/objects/config'
@@ -44,11 +44,13 @@ export async function flowRunArtifactFactory<T extends ArtifactFactoryOptions>(o
 
     const globalPosition = element.getGlobalPosition()
 
+    const isCluster = isArtifactClusterFactory(factory)
+
     const position = {
       x: globalPosition.x,
       y: globalPosition.y,
-      width: element.width * viewport.scale.x,
-      height: element.height * viewport.scale.y,
+      width: isCluster ? element.width : element.width * viewport.scale.x,
+      height: isCluster ? element.height : element.height * viewport.scale.y,
     }
 
     const selectSettings: ArtifactSelection | ArtifactsSelection = itemIsClusterFactory(factory)

--- a/src/factories/flowRunArtifact.ts
+++ b/src/factories/flowRunArtifact.ts
@@ -1,5 +1,5 @@
 import { ArtifactFactory, artifactFactory } from '@/factories/artifact'
-import { ArtifactClusterFactory, ArtifactClusterFactoryRenderProps, artifactClusterFactory, isArtifactClusterFactory } from '@/factories/artifactCluster'
+import { ArtifactClusterFactory, ArtifactClusterFactoryRenderProps, artifactClusterFactory } from '@/factories/artifactCluster'
 import { ArtifactSelection, ArtifactsSelection, RunGraphArtifact } from '@/models'
 import { waitForApplication, waitForViewport } from '@/objects'
 import { waitForConfig } from '@/objects/config'
@@ -44,13 +44,11 @@ export async function flowRunArtifactFactory<T extends ArtifactFactoryOptions>(o
 
     const globalPosition = element.getGlobalPosition()
 
-    const isCluster = isArtifactClusterFactory(factory)
-
     const position = {
       x: globalPosition.x,
       y: globalPosition.y,
-      width: isCluster ? element.width : element.width * viewport.scale.x,
-      height: isCluster ? element.height : element.height * viewport.scale.y,
+      width: element.width,
+      height: element.height,
     }
 
     const selectSettings: ArtifactSelection | ArtifactsSelection = itemIsClusterFactory(factory)


### PR DESCRIPTION
For root level artifacts, the viewport scale was being included in selection dimensions, which caused inaccurate overlay boxes from the popover.