### PR TITLE
Fix: Graph centering too low

### DIFF
--- a/src/objects/viewport.ts
+++ b/src/objects/viewport.ts
@@ -103,15 +103,23 @@ async function centerViewportOnNodes({ x, y, width, height, animate }: CenterVie
   const config = await waitForConfig()
   const viewport = await waitForViewport()
 
-  const guidesOffset = config.styles.guideTextSize + config.styles.guideTextTopPadding
-  const widthWithGap = width + config.styles.columnGap * 2
-  const heightWithGap = height + config.styles.rowGap * 2 + guidesOffset * 2
+  const {
+    guideTextSize,
+    guideTextTopPadding,
+    columnGap,
+    rowGap,
+    eventTargetSize,
+  } = config.styles
+
+  const guidesOffset = guideTextSize + guideTextTopPadding
+  const widthWithGap = width + columnGap * 2
+  const heightWithGap = height + rowGap * 4 + guidesOffset + eventTargetSize
   const scale = viewport.findFit(widthWithGap, heightWithGap)
 
   viewport.animate({
     position: {
       x: x + width / 2,
-      y: y + height / 2 - guidesOffset,
+      y: y + height / 2 + guidesOffset,
     },
     scale: Math.min(scale, 1),
     time: animate ? config.animationDuration : 0,


### PR DESCRIPTION
Before:
<img width="1236" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6776415/6dc694c2-4f73-4529-a908-985cda173449">

After:
<img width="1239" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6776415/dc8e4258-802a-489a-b5e9-7c6cd4ec00bb">
