### PR TITLE
Fix: Prefent node dimming if selecting from differing scope

### DIFF
--- a/src/factories/nodes.ts
+++ b/src/factories/nodes.ts
@@ -344,7 +344,7 @@ export async function nodesContainerFactory() {
     const settings = await waitForSettings()
     const selected = getSelectedRunGraphNode()
 
-    if (!selected || settings.disableEdges) {
+    if (settings.disableEdges || !selected || !runData?.nodes.has(selected.id)) {
       highlightPath([])
       return
     }

--- a/src/objects/selection.ts
+++ b/src/objects/selection.ts
@@ -1,4 +1,3 @@
-import { RunGraphNodeKind, runGraphNodeKinds } from '@/models'
 import {
   GraphItemSelection,
   NodeSelection,
@@ -91,7 +90,7 @@ export function isSelected(item: GraphItemSelection): boolean {
 }
 
 export function getSelectedRunGraphNode(): NodeSelection | null {
-  if (!!selected && runGraphNodeKinds.includes(selected.kind as RunGraphNodeKind)) {
+  if (!!selected && isNodeSelection(selected)) {
     return selected as NodeSelection
   }
 


### PR DESCRIPTION
Currently, when selecting a subflow, the parent node is dimmed, causing all subflow nodes to also dim regardless of whether or not they contain a selection.

<img width="1234" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6776415/04e7849f-ce15-403b-a987-06d3f6627b02">

This PR makes it so that nodes aren't dimmed if the selected node doesn't exist in the current scope of nodes. Ideally, we'd find the subflow node containing the selection and highlight the path. This get's tricky with recursion, like if you select a subflow node that's 5 subflows deep. So this is a fast and improved solution, but not quite ideal. If I have time I'll pursue the ideal solution in a way that doesn't necessitate too much recursion.

After:
<img width="1230" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6776415/e26f2cc4-fd61-409b-8fb3-fc666006ab68">
