### PR TITLE
Fix: Gradient fills on nodes if zoomed screen

### DIFF
--- a/src/objects/application.ts
+++ b/src/objects/application.ts
@@ -29,7 +29,7 @@ function createApplication(stage: HTMLDivElement): void {
     backgroundAlpha: 0,
     resizeTo: stage,
     antialias: true,
-    resolution: window.devicePixelRatio,
+    resolution: Math.ceil(window.devicePixelRatio),
   })
 
   // for setting the viewport above the guides


### PR DESCRIPTION
Resolves https://github.com/PrefectHQ/graphs/issues/459

Nodes were appearing to have gradient fills when the browser was zoomed:
<img width="1163" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6776415/3475baa2-2420-47a2-8d24-f05dfa1a82bf">

After digging into the PIXI discord for a while, it seems that this happens when floats are provided for the resolution (e.g. `2.5` or `1.7777`). Rounding this resolution up to a whole number solves the issue and errs on the side of higher resolution rather than lower, so things still render nice and sharp.

<img width="1165" alt="image" src="https://github.com/PrefectHQ/graphs/assets/6776415/4a268d06-b235-4531-a453-a4195bd40a51">
