### PR TITLE
Fix: Event creation lock needs to return

### DIFF
--- a/src/factories/runEvents.ts
+++ b/src/factories/runEvents.ts
@@ -55,7 +55,7 @@ export async function runEventsFactory({ isRoot, parentStartDate }: RunEventsFac
     }
 
     if (eventsCreationPromises.has(event.id)) {
-      await eventsCreationPromises.get(event.id)
+      return await eventsCreationPromises.get(event.id)
     }
 
     const eventCreationPromise = (async () => {


### PR DESCRIPTION
The `createEvent` function wasn't returning the `eventsCreationPromises`, so it would await it then proceed to create a duplicate. 