### PR TITLE
Fix: Use static polling interval for events

### DIFF
--- a/src/factories/data.ts
+++ b/src/factories/data.ts
@@ -27,7 +27,7 @@ export async function dataFactory(runId: string, callback: DataCallback) {
 
   // todo: need a global way of stopping this when the graph is stopped
   function stop(): void {
-    clearInterval(interval)
+    clearTimeout(interval)
   }
 
   return {

--- a/src/factories/eventData.ts
+++ b/src/factories/eventData.ts
@@ -1,5 +1,4 @@
 import { MaybeRefOrGetter, toValue } from 'vue'
-import { getIntervalForDataSize } from '@/factories/data'
 import { RunGraphEvent, RunGraphFetchEventsOptions } from '@/models'
 import { waitForConfig } from '@/objects/config'
 import { waitForRunData } from '@/objects/nodes'
@@ -28,7 +27,7 @@ export async function eventDataFactory(
     }
 
     if (!runGraphData.end_time) {
-      interval = setTimeout(() => start(), getIntervalForDataSize(runGraphData))
+      interval = setTimeout(() => start(), config.fetchEventsInterval)
     }
   }
 

--- a/src/factories/eventData.ts
+++ b/src/factories/eventData.ts
@@ -33,7 +33,7 @@ export async function eventDataFactory(
 
   // todo: need a global way of stopping this when the graph is stopped
   function stop(): void {
-    clearInterval(interval)
+    clearTimeout(interval)
   }
 
   return {

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -123,6 +123,7 @@ export type RunGraphConfig = {
   runId: string,
   fetch: RunGraphFetch,
   fetchEvents?: RunGraphFetchEvents,
+  fetchEventsInterval?: number,
   animationDuration?: number,
   styles?: RunGraphStyles,
   disableAnimationsThreshold?: number,

--- a/src/objects/config.ts
+++ b/src/objects/config.ts
@@ -11,6 +11,7 @@ const defaults: Omit<RequiredGraphConfig, 'runId' | 'fetch'> = {
   disableAnimationsThreshold: 500,
   disableEdgesThreshold: 500,
   fetchEvents: () => [],
+  fetchEventsInterval: 30000,
   styles: {
     colorMode: 'dark',
     rowGap: 24,


### PR DESCRIPTION
Instead of using adaptive polling for events, use a static interval defined in the graph config.