### PR TITLE
BugFix: make sure occurred is always set

### DIFF
--- a/src/factories/eventData.ts
+++ b/src/factories/eventData.ts
@@ -1,5 +1,5 @@
 import { MaybeRefOrGetter, toValue } from 'vue'
-import { RunGraphEvent, RunGraphFetchEventsOptions } from '@/models'
+import { RunGraphEvent, RunGraphFetchEventsContext } from '@/models'
 import { waitForConfig } from '@/objects/config'
 import { waitForRunData } from '@/objects/nodes'
 
@@ -7,9 +7,8 @@ type EventDataCallback = (data: RunGraphEvent[]) => void
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function eventDataFactory(
-  runId: string,
+  context: MaybeRefOrGetter<RunGraphFetchEventsContext>,
   callback: EventDataCallback,
-  options?: MaybeRefOrGetter<RunGraphFetchEventsOptions>,
 ) {
   const runGraphData = await waitForRunData()
   const config = await waitForConfig()
@@ -19,7 +18,7 @@ export async function eventDataFactory(
 
   async function start(): Promise<void> {
     try {
-      data = await config.fetchEvents(runId, toValue(options))
+      data = await config.fetchEvents(toValue(context))
 
       callback(data)
     } catch (error) {

--- a/src/factories/nodeFlowRun.ts
+++ b/src/factories/nodeFlowRun.ts
@@ -20,7 +20,7 @@ import { runStatesFactory } from '@/factories/runStates'
 import { RunGraphArtifact, RunGraphEvent, RunGraphStateEvent } from '@/models'
 import { BoundsContainer } from '@/models/boundsContainer'
 import { NodeSize } from '@/models/layout'
-import { RunGraphFetchEventsOptions, RunGraphNode } from '@/models/RunGraph'
+import { RunGraphFetchEventsContext, RunGraphNode } from '@/models/RunGraph'
 import { waitForConfig } from '@/objects/config'
 import { cull } from '@/objects/culling'
 import { layout, waitForSettings } from '@/objects/settings'
@@ -73,17 +73,15 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     renderBorder()
   })
 
-  function getEventFactoryOptions(): RunGraphFetchEventsOptions {
-    return {
-      since: internalNode.start_time,
-      until: internalNode.end_time ?? new Date(),
-    }
-  }
-  const { start: startEventsData, stop: stopEventsData } = await eventDataFactory(internalNode.id, data => {
+  const { start: startEventsData, stop: stopEventsData } = await eventDataFactory(() => ({
+    nodeId: internalNode.id,
+    since: internalNode.start_time,
+    until: internalNode.end_time ?? new Date(),
+  }), data => {
     hasEvents = data.length > 0
 
     renderEvents(data)
-  }, getEventFactoryOptions)
+  })
 
   container.addChild(bar)
   container.addChild(label)

--- a/src/models/RunGraph.ts
+++ b/src/models/RunGraph.ts
@@ -48,13 +48,13 @@ export function isRunGraphNodeType(value: unknown): value is RunGraphNodeKind {
 
 export type RunGraphFetch = (runId: string) => RunGraphData | Promise<RunGraphData>
 
-export type RunGraphFetchEventsOptions = {
-  since?: Date,
-  until?: Date,
+export type RunGraphFetchEventsContext = {
+  nodeId: string,
+  since: Date,
+  until: Date,
 }
 export type RunGraphFetchEvents = (
-  runId: string,
-  options?: RunGraphFetchEventsOptions,
+  context: RunGraphFetchEventsContext,
 ) => RunGraphEvent[] | Promise<RunGraphEvent[]>
 
 export type RunGraphNodeStyles = {

--- a/src/objects/flowRunEvents.ts
+++ b/src/objects/flowRunEvents.ts
@@ -5,6 +5,7 @@ import { RunGraphEvent } from '@/models'
 import { waitForApplication } from '@/objects/application'
 import { waitForConfig } from '@/objects/config'
 import { EventKey, emitter, waitForEvent } from '@/objects/events'
+import { waitForRunData } from '@/objects/nodes'
 import { layout, waitForSettings } from '@/objects/settings'
 
 let stopEventData: (() => void) | null = null
@@ -14,6 +15,7 @@ export async function startFlowRunEvents(): Promise<void> {
   const application = await waitForApplication()
   const config = await waitForConfig()
   const settings = await waitForSettings()
+  const data = await waitForRunData()
 
   const { element, render: renderEvents, update } = await runEventsFactory({ isRoot: true })
 
@@ -30,7 +32,11 @@ export async function startFlowRunEvents(): Promise<void> {
     await renderEvents(data)
   }
 
-  const response = await eventDataFactory(config.runId, data => {
+  const response = await eventDataFactory(() => ({
+    nodeId: config.runId,
+    since: data.start_time,
+    until: data.end_time ?? new Date(),
+  }), data => {
     const event: EventKey = rootGraphEvents ? 'eventDataUpdated' : 'eventDataCreated'
 
     rootGraphEvents = data


### PR DESCRIPTION
# Description
Makes sure that event queries always have a start/end time so we don't end up with queries that are unscoped