### PR TITLE
BugFix: properly set the cache key

### DIFF
--- a/src/factories/node.ts
+++ b/src/factories/node.ts
@@ -191,8 +191,7 @@ export async function nodeContainerFactory(node: RunGraphNode) {
       layout.horizontal,
       layout.horizontalScaleMultiplier,
       config.styles.colorMode,
-      artifactCacheKey && settings.disableArtifacts,
-      artifactCacheKey,
+      settings.disableArtifacts || artifactCacheKey,
     ]
 
     return values.join('-')


### PR DESCRIPTION
In my last PR we were updating the cache key with artifact keys/values even if artifacts were disabled. This fixes the issue.