### PR TITLE
Update scripts to first run the associated command in the core project

### DIFF
--- a/vue/package.json
+++ b/vue/package.json
@@ -4,7 +4,8 @@
   "main": "main.ts",
   "scripts": {
     "serve": "vite",
-    "build": "vite build"
+    "build": "cd ../core && npm run build && cd ../vue && vite build",
+    "dev": "cd ../core && npm run dev & cd ../vue && npm run serve"
   },
   "author": "Craig Harshbarger",
   "license": "ISC",


### PR DESCRIPTION
# Description
In order to build the demo the core project needs to be built. So for dev and build commands we need to first dev/build the core project. 