### PR TITLE
Revert "update type to match api"

### DIFF
--- a/core/src/factories/node.ts
+++ b/core/src/factories/node.ts
@@ -182,7 +182,7 @@ export async function nodeContainerFactory(node: RunGraphNode, nestedGraphData: 
   }
 
   function getNodeCacheKey(nodeData: RunGraphNode): string {
-    const endTime = nodeData.end_time ? new Date(nodeData.end_time) : new Date()
+    const endTime = nodeData.end_time ?? new Date()
     const artifactCacheKey = nodeData.artifacts?.map(artifact => {
       if (artifact.type === 'progress') {
         return `${artifact.id}-${artifact.data}`

--- a/core/src/factories/nodeFlowRun.ts
+++ b/core/src/factories/nodeFlowRun.ts
@@ -42,8 +42,8 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
 
   const { element: nodesContainer, render: renderNodes, getSize: getNodesSize, stopWorker: stopNodesWorker } = await nodesContainerFactory()
   const { element: nodesState, render: renderNodesState } = await runStatesFactory()
-  const { element: nodesEvents, render: renderNodesEvents, update: updateNodesEvents } = await runEventsFactory({ parentStartDate: new Date(node.start_time) })
-  const { element: nodesArtifacts, render: renderNodesArtifacts, update: updateNodesArtifacts } = await runArtifactsFactory({ parentStartDate: new Date(node.start_time) })
+  const { element: nodesEvents, render: renderNodesEvents, update: updateNodesEvents } = await runEventsFactory({ parentStartDate: node.start_time })
+  const { element: nodesArtifacts, render: renderNodesArtifacts, update: updateNodesArtifacts } = await runArtifactsFactory({ parentStartDate: node.start_time })
 
   let hasEvents = false
   let hasArtifacts = false
@@ -77,8 +77,8 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
 
   const { start: startEventsData, stop: stopEventsData } = await eventDataFactory(() => ({
     nodeId: internalNode.id,
-    since: new Date(internalNode.start_time),
-    until: internalNode.end_time ? new Date(internalNode.end_time) : new Date(),
+    since: internalNode.start_time,
+    until: internalNode.end_time ?? new Date(),
   }), data => {
     hasEvents = data.length > 0
 
@@ -153,7 +153,7 @@ export async function flowRunContainerFactory(node: RunGraphNode) {
     const { width } = bar
 
     await renderNodesState(data ?? undefined, {
-      parentStartDate: new Date(internalNode.start_time),
+      parentStartDate: internalNode.start_time,
       width,
       height,
     })

--- a/core/src/factories/nodes.ts
+++ b/core/src/factories/nodes.ts
@@ -169,7 +169,7 @@ export async function nodesContainerFactory() {
       type: 'layout',
       data,
       widths,
-      horizontalSettings: horizontalSettingsFactory(new Date(data.start_time)),
+      horizontalSettings: horizontalSettingsFactory(data.start_time),
       verticalSettings: verticalSettingsFactory(),
     })
   }
@@ -319,13 +319,10 @@ export async function nodesContainerFactory() {
       return columns.getTotalValue(nodesLayout.maxColumn)
     }
 
-    const startTime = new Date(runData.start_time)
-    const endTime = runData.end_time ? new Date(runData.end_time) : new Date()
-
-    const settings = horizontalSettingsFactory(startTime)
+    const settings = horizontalSettingsFactory(runData.start_time)
     const scale = horizontalScaleFactory(settings)
-    const end = scale(endTime)
-    const start = scale(startTime)
+    const end = scale(runData.end_time ?? new Date())
+    const start = scale(runData.start_time)
     const width = end - start
 
     return width

--- a/core/src/models/RunGraph.ts
+++ b/core/src/models/RunGraph.ts
@@ -13,8 +13,8 @@ export type RunGraphProps = {
 
 export type RunGraphData = {
   root_node_ids: string[],
-  start_time: string,
-  end_time: string | null,
+  start_time: Date,
+  end_time: Date | null,
   nodes: RunGraphNodes,
   artifacts?: RunGraphArtifact[],
   states?: RunGraphStateEvent[],
@@ -33,8 +33,8 @@ export type RunGraphNode = {
   id: string,
   label: string,
   state_type: StateType,
-  start_time: string,
-  end_time: string | null,
+  start_time: Date,
+  end_time: Date | null,
   parents: RunGraphEdge[],
   children: RunGraphEdge[],
   artifacts?: RunGraphArtifact[],

--- a/core/src/objects/flowRunEvents.ts
+++ b/core/src/objects/flowRunEvents.ts
@@ -34,8 +34,8 @@ export async function startFlowRunEvents(): Promise<void> {
 
   const response = await eventDataFactory(() => ({
     nodeId: config.runId,
-    since: new Date(data.start_time),
-    until: data.end_time ? new Date(data.end_time) : new Date(),
+    since: data.start_time,
+    until: data.end_time ?? new Date(),
   }), data => {
     const event: EventKey = rootGraphEvents ? 'eventDataUpdated' : 'eventDataCreated'
 

--- a/core/src/objects/scale.ts
+++ b/core/src/objects/scale.ts
@@ -8,11 +8,10 @@ let scale: HorizontalScale | null = null
 
 export async function startScale(): Promise<void> {
   const data = await waitForRunData()
-  const startTime = new Date(data.start_time)
 
-  setHorizontalScale(startTime)
+  setHorizontalScale(data.start_time)
 
-  emitter.on('layoutSettingsUpdated', () => setHorizontalScale(startTime))
+  emitter.on('layoutSettingsUpdated', () => setHorizontalScale(data.start_time))
 }
 
 export function stopScale(): void {

--- a/core/src/objects/viewport.ts
+++ b/core/src/objects/viewport.ts
@@ -140,11 +140,9 @@ async function centerViewportOnStartAndEnd({ animate }: CenterViewportParameters
   const styles = await waitForStyles()
   const viewport = await waitForViewport()
   const graphScale = await waitForScale()
-  const startTime = new Date(data.start_time)
-  const endTime = data.end_time ? new Date(data.end_time) : new Date()
 
-  let startX = graphScale(startTime) - styles.columnGap
-  let endX = graphScale(endTime) + styles.columnGap
+  let startX = graphScale(data.start_time) - styles.columnGap
+  let endX = graphScale(data.end_time ?? new Date()) + styles.columnGap
 
   if (startX > endX) {
     const temp = startX

--- a/core/src/workers/layouts/horizontal.ts
+++ b/core/src/workers/layouts/horizontal.ts
@@ -47,7 +47,7 @@ function getHorizontalTimeLayout({ data, horizontalSettings }: ClientLayoutMessa
   const layout: HorizontalLayout = new Map()
 
   for (const [nodeId, node] of data.nodes) {
-    const value = scale(new Date(node.start_time))
+    const value = scale(node.start_time)
 
     layout.set(nodeId, {
       column: value,
@@ -65,7 +65,7 @@ function getHorizontalLeftAlignedLayout({ data, horizontalSettings }: ClientLayo
   for (const [nodeId] of data.nodes) {
     layout.set(nodeId, {
       column: 0,
-      x: scale(new Date(data.start_time)),
+      x: scale(data.start_time),
     })
   }
 

--- a/core/src/workers/layouts/vertical.ts
+++ b/core/src/workers/layouts/vertical.ts
@@ -32,8 +32,8 @@ function getVerticalDurationSortedLayout(message: ClientLayoutMessage): Vertical
   const layout: VerticalLayout = new Map()
 
   const nodes = [...message.data.nodes.values()].sort((nodeA, nodeB) => {
-    const aDuration = (nodeA.end_time ? new Date(nodeA.end_time).getTime() : new Date().getTime()) - new Date(nodeA.start_time).getTime()
-    const bDuration = (nodeB.end_time ? new Date(nodeB.end_time).getTime() : new Date().getTime()) - new Date(nodeB.start_time).getTime()
+    const aDuration = (nodeA.end_time ? nodeA.end_time.getTime() : new Date().getTime()) - nodeA.start_time.getTime()
+    const bDuration = (nodeB.end_time ? nodeB.end_time.getTime() : new Date().getTime()) - nodeB.start_time.getTime()
 
     return bDuration - aDuration
   })


### PR DESCRIPTION
This reverts commit 29d703dcc0243bde97603b3e25aad42c63302b14.

I realized that the api response cannot be used without mapping because json doesn't preserve the `Map`s we're using for lookups. So since I'm going to have to map the api response some anyway might as well convert the dates ahead of time to so this can be optimized. 