### PR TITLE
Remove account and workspace from event model

### DIFF
--- a/core/src/models/event.ts
+++ b/core/src/models/event.ts
@@ -13,11 +13,9 @@ export type EventRelatedResource = RunGraphEventResource & {
 export type RunGraphEvent = {
   id: string,
   occurred: Date,
-  account: string,
   event: string,
   payload: unknown,
   received: Date,
   related: EventRelatedResource[],
   resource: RunGraphEventResource,
-  workspace: string | null,
 }


### PR DESCRIPTION
# Description
These fields are unused and also not available in oss so we should just remove them. 