### PR TITLE
Support custom fonts

### DIFF
--- a/core/src/factories/guide.ts
+++ b/core/src/factories/guide.ts
@@ -17,13 +17,13 @@ export async function guideFactory() {
   const viewport = await waitForViewport()
   const settings = await waitForSettings()
   const styles = await waitForStyles()
-  const { inter } = await waitForFonts()
+  const font = await waitForFonts()
   const element = new Container()
 
   const rectangle = await rectangleFactory()
   element.addChild(rectangle)
 
-  const label = inter('')
+  const label = font('')
   element.addChild(label)
 
   let scale = await waitForScale()

--- a/core/src/factories/label.ts
+++ b/core/src/factories/label.ts
@@ -8,10 +8,10 @@ type NodeLabelFactoryOptions = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function nodeLabelFactory({ cullAtZoomThreshold = true }: NodeLabelFactoryOptions = {}) {
-  const { inter } = await waitForFonts()
+  const font = await waitForFonts()
   const cull = await waitForLabelCull()
 
-  const label = inter('')
+  const label = font('')
 
   if (cullAtZoomThreshold) {
     cull.add(label)

--- a/core/src/models/RunGraph.ts
+++ b/core/src/models/RunGraph.ts
@@ -71,6 +71,7 @@ export type RunGraphStateStyles = {
 }
 
 export type RunGraphStyles = {
+  font?: { fontFamily: string, type: 'BitmapFont' | 'WebFont' },
   rowGap?: number,
   columnGap?: number,
   textDefault?: ColorSource,

--- a/core/src/objects/events.ts
+++ b/core/src/objects/events.ts
@@ -8,7 +8,7 @@ import { LayoutSettings } from '@/models/layout'
 import { RequiredGraphConfig, RunGraphData, RunGraphStyles } from '@/models/RunGraph'
 import { GraphItemSelection } from '@/models/selection'
 import { ViewportDateRange } from '@/models/viewport'
-import { Fonts } from '@/objects/fonts'
+import { FontFactory } from '@/objects/fonts'
 import { VisibilityCull } from '@/services/visibilityCull'
 
 type Events = {
@@ -23,7 +23,7 @@ type Events = {
   viewportMoved: null,
   configCreated: RequiredGraphConfig,
   configUpdated: RequiredGraphConfig,
-  fontsLoaded: Fonts,
+  fontLoaded: FontFactory,
   containerCreated: Container,
   layoutSettingsUpdated: LayoutSettings,
   layoutSettingsCreated: LayoutSettings,

--- a/core/src/objects/styles.ts
+++ b/core/src/objects/styles.ts
@@ -3,6 +3,7 @@ import { waitForConfig } from '@/objects/config'
 import { emitter, waitForEvent } from '@/objects/events'
 
 const defaults: (theme: RunGraphTheme) => Required<RunGraphStyles> = (theme) => ({
+  font: { fontFamily: "ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'", type: 'BitmapFont' },
   rowGap: 24,
   columnGap: 32,
   textDefault: theme === 'dark' ? '#ffffff' : '#161618',


### PR DESCRIPTION
# Description
OSS is currently using the default fonts specified by tailwind so the graph always times out loading the webfont it specifies. Updating the config to allow for both web fonts and bitmap fonts and updating the default to match tailwind. 