### PR TITLE
chore: Configure dependabot to group npm updates into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: "/core/"
     schedule:
       interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Updates dependabot configuration to consolidate all npm dependency updates into a single pull request
- Prevents multiple individual PRs for each dependency update
- Uses the `groups` feature to combine all npm packages into one PR