### PR TITLE
feat: add rich artifact type

### DIFF
--- a/core/src/models/artifact.ts
+++ b/core/src/models/artifact.ts
@@ -6,6 +6,7 @@ export const artifactTypes = [
   'table',
   'progress',
   'image',
+  'rich',
   'unknown',
 ] as const
 
@@ -30,5 +31,6 @@ export const artifactTypeIconMap = {
   result: 'ArtifactResult',
   image: 'ArtifactImage',
   progress: 'ArtifactProgress',
+  rich: 'Artifact',
   unknown: 'Artifact',
 } as const satisfies Record<ArtifactType, IconName>


### PR DESCRIPTION
Adds 'rich' to artifact types for HTML/JS content rendered in sandboxed iframes.

## Release Order
```
graphs (this PR)
    ↓
prefect-ui-library#3109 (bump @prefecthq/graphs)
    ↓
prefect#19726 (bump @prefecthq/prefect-ui-library)
```

**No upstream dependencies.** Merge and release this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)