### PR TITLE
PLA-2798: migrate graphs workflows to prefect-ci-bot trust-tier Apps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,18 +24,35 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Generate prefect-ci-bot-public release token
+        id: release_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
+          private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
+
       - uses: prefecthq/actions-release-ui-components@main
         id: release-ui-components
         with:
           NPM_TOKEN: ${{ secrets.PREFECT_UI_COMPONENTS_NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.UI_COMPONENTS_CONTENTS_PRS_RW }}
+          GITHUB_TOKEN: ${{ steps.release_token.outputs.token }}
           RELEASE_TYPE: ${{ inputs.release_type }}
           WORKING_DIR: ./core
+
+      - name: Generate prefect-ci-bot-public downstream token
+        if: ${{ steps.release-ui-components.outputs.type }}
+        id: downstream_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.PREFECT_CI_BOT_PUBLIC_CLIENT_ID }}
+          private-key: ${{ secrets.PREFECT_CI_BOT_PUBLIC_PRIVATE_KEY }}
+          owner: PrefectHQ
+          repositories: prefect-ui-library
 
       - uses: prefecthq/actions-trigger-downstream-npm-package-updates@main
         id: trigger-downstream-npm-package-update-prefect-ui-library
         if: ${{ steps.release-ui-components.outputs.type }}
         with:
-          GITHUB_TOKEN: ${{ secrets.PREFECT_UI_LIBRARY_ACTIONS_RW }}
+          GITHUB_TOKEN: ${{ steps.downstream_token.outputs.token }}
           DOWNSTREAM_REPO_NAME: prefect-ui-library
           RELEASE_TAG: ${{ steps.release-ui-components.outputs.version}}


### PR DESCRIPTION
## Summary

Per the three-tier App design ([PLA-2825](https://linear.app/prefect/issue/PLA-2825)), `graphs` is a public repo so workflows now use `prefect-ci-bot-public` for public-to-public operations and `prefect-ci-bot-bridge` when reaching internal targets like `nebula-ui`.

Migrates `release.yml` to use `prefect-ci-bot-public` for both the same-repo release-ui-components action and the downstream trigger to `prefect-ui-library`.

Resolves the `graphs` portion of PLA-2798.

## Test plan

- [ ] After merge, cut the next release on this repo via `workflow_dispatch` and verify all downstream triggers succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)